### PR TITLE
Update prices.json with 01 AI

### DIFF
--- a/prices.json
+++ b/prices.json
@@ -1022,6 +1022,69 @@
     "output": 0.4286
   },
   {
+    "model": "yi-lightning",
+    "type": "tokens",
+    "channel_type": 33,
+    "input": 0.0707,
+    "output": 0.0707
+  },
+  {
+    "model": "yi-large",
+    "type": "tokens",
+    "channel_type": 33,
+    "input": 1.4286,
+    "output": 1.4286
+  },
+  {
+    "model": "yi-medium",
+    "type": "tokens",
+    "channel_type": 33,
+    "input": 0.1786,
+    "output": 0.1786
+  },
+  {
+    "model": "yi-vision",
+    "type": "tokens",
+    "channel_type": 33,
+    "input": 0.4286,
+    "output": 0.4286
+  },
+  {
+    "model": "yi-medium-200k",
+    "type": "tokens",
+    "channel_type": 33,
+    "input": 0.8571,
+    "output": 0.8571
+  },
+  {
+    "model": "yi-spark",
+    "type": "tokens",
+    "channel_type": 33,
+    "input": 0.0714,
+    "output": 0.0714
+  },
+  {
+    "model": "yi-large-rag",
+    "type": "tokens",
+    "channel_type": 33,
+    "input": 1.7857,
+    "output": 1.7857
+  },
+  {
+    "model": "yi-large-fc",
+    "type": "tokens",
+    "channel_type": 33,
+    "input": 1.4286,
+    "output": 1.4286
+  },
+  {
+    "model": "yi-large-turbo",
+    "type": "tokens",
+    "channel_type": 33,
+    "input": 0.8571,
+    "output": 0.8571
+  },
+  {
     "model": "mj_blend",
     "type": "times",
     "channel_type": 34,


### PR DESCRIPTION
恭喜 yi-lightning 登顶 lmsys 第六
更新下 01-AI 的模型和价格，参照：https://platform.lingyiwanwu.com/docs#%E6%A8%A1%E5%9E%8B%E4%B8%8E%E8%AE%A1%E8%B4%B9

<img width="1272" alt="image" src="https://github.com/user-attachments/assets/11042b3a-ad95-4a42-a9a5-a95146325e8a">


Additions to `prices.json`:

我已确认该 PR 已自测通过，相关截图如下：
