### PR TITLE
增加aws bedrock Claude Cross-region模型支持

### DIFF
--- a/providers/bedrock/category/base.go
+++ b/providers/bedrock/category/base.go
@@ -42,20 +42,20 @@ func GetCategory(modelName string) (*Category, error) {
 func GetModelName(modelName string) string {
 	bedrockMap := map[string]string{
 		//cross-region model id
-		"us.anthropic.claude-3-sonnet-20240229":   "us.anthropic.claude-3-sonnet-20240229-v1:0",
-		"us.anthropic.claude-3-opus-20240229":     "us.anthropic.claude-3-opus-20240229-v1:0",
-		"us.anthropic.claude-3-haiku-20240307":    "us.anthropic.claude-3-haiku-20240307-v1:0",
-		"us.anthropic.claude-3-5-sonnet-20240620": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
-		"us.anthropic.claude-3-5-sonnet-20241022": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-		"us.anthropic.claude-3-5-haiku-20241022":  "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+		"us.claude-3-sonnet-20240229":   "us.anthropic.claude-3-sonnet-20240229-v1:0",
+		"us.claude-3-opus-20240229":     "us.anthropic.claude-3-opus-20240229-v1:0",
+		"us.claude-3-haiku-20240307":    "us.anthropic.claude-3-haiku-20240307-v1:0",
+		"us.claude-3-5-sonnet-20240620": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"us.claude-3-5-sonnet-20241022": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"us.claude-3-5-haiku-20241022":  "us.anthropic.claude-3-5-haiku-20241022-v1:0",
 
-		"eu.anthropic.claude-3-sonnet-20240229":   "eu.anthropic.claude-3-sonnet-20240229-v1:0",
-		"eu.anthropic.claude-3-5-sonnet-20240620": "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
-		"eu.anthropic.claude-3-haiku-20240307":    "eu.anthropic.claude-3-haiku-20240307-v1:0",
+		"eu.claude-3-sonnet-20240229":   "eu.anthropic.claude-3-sonnet-20240229-v1:0",
+		"eu.claude-3-5-sonnet-20240620": "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"eu.claude-3-haiku-20240307":    "eu.anthropic.claude-3-haiku-20240307-v1:0",
 
-		"apac.anthropic.claude-3-sonnet-20240229":   "apac.anthropic.claude-3-sonnet-20240229-v1:0",
-		"apac.anthropic.claude-3-5-sonnet-20240620": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
-		"apac.anthropic.claude-3-haiku-20240307":    "apac.anthropic.claude-3-haiku-20240307-v1:0",
+		"apac.claude-3-sonnet-20240229":   "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+		"apac.claude-3-5-sonnet-20240620": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"apac.claude-3-haiku-20240307":    "apac.anthropic.claude-3-haiku-20240307-v1:0",
 		//base model id
 		"claude-3-5-sonnet-20240620": "anthropic.claude-3-5-sonnet-20240620-v1:0",
 		"claude-3-5-sonnet-20241022": "anthropic.claude-3-5-sonnet-20241022-v2:0",

--- a/providers/bedrock/category/base.go
+++ b/providers/bedrock/category/base.go
@@ -21,16 +21,12 @@ type Category struct {
 func GetCategory(modelName string) (*Category, error) {
 	modelName = GetModelName(modelName)
 	// 获取provider
-	parts := strings.Split(modelName, ".")
-	var provider string
+	provider := ""
 
-	// 如果为cross-region取指针下标1为供应商标记
-	if len(parts) > 2 {
-		provider = parts[1]
-	} else {
-		// 否则保持原有逻辑,取第一个点前的内容
-		provider = parts[0]
+	if strings.Contains(modelName, "anthropic") {
+		provider = "anthropic"
 	}
+
 	if category, exists := CategoryMap[provider]; exists {
 		category.ModelName = modelName
 		return &category, nil

--- a/providers/bedrock/category/base.go
+++ b/providers/bedrock/category/base.go
@@ -42,20 +42,20 @@ func GetCategory(modelName string) (*Category, error) {
 func GetModelName(modelName string) string {
 	bedrockMap := map[string]string{
 		//cross-region model id
-		"us-anthropic.claude-3-sonnet-20240229":   "us.anthropic.claude-3-sonnet-20240229-v1:0",
-		"us-anthropic.claude-3-opus-20240229":     "us.anthropic.claude-3-opus-20240229-v1:0",
-		"us-anthropic.claude-3-haiku-20240307":    "us.anthropic.claude-3-haiku-20240307-v1:0",
-		"us-anthropic.claude-3-5-sonnet-20240620": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
-		"us-anthropic.claude-3-5-sonnet-20241022": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-		"us-anthropic.claude-3-5-haiku-20241022":  "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+		"us.anthropic.claude-3-sonnet-20240229":   "us.anthropic.claude-3-sonnet-20240229-v1:0",
+		"us.anthropic.claude-3-opus-20240229":     "us.anthropic.claude-3-opus-20240229-v1:0",
+		"us.anthropic.claude-3-haiku-20240307":    "us.anthropic.claude-3-haiku-20240307-v1:0",
+		"us.anthropic.claude-3-5-sonnet-20240620": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"us.anthropic.claude-3-5-sonnet-20241022": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"us.anthropic.claude-3-5-haiku-20241022":  "us.anthropic.claude-3-5-haiku-20241022-v1:0",
 
-		"eu-anthropic.claude-3-sonnet-20240229":   "eu.anthropic.claude-3-sonnet-20240229-v1:0",
-		"eu-anthropic.claude-3-5-sonnet-20240620": "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
-		"eu-anthropic.claude-3-haiku-20240307":    "eu.anthropic.claude-3-haiku-20240307-v1:0",
+		"eu.anthropic.claude-3-sonnet-20240229":   "eu.anthropic.claude-3-sonnet-20240229-v1:0",
+		"eu.anthropic.claude-3-5-sonnet-20240620": "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"eu.anthropic.claude-3-haiku-20240307":    "eu.anthropic.claude-3-haiku-20240307-v1:0",
 
-		"apac-anthropic.claude-3-sonnet-20240229":   "apac.anthropic.claude-3-sonnet-20240229-v1:0",
-		"apac-anthropic.claude-3-5-sonnet-20240620": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
-		"apac-anthropic.claude-3-haiku-20240307":    "apac.anthropic.claude-3-haiku-20240307-v1:0",
+		"apac.anthropic.claude-3-sonnet-20240229":   "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+		"apac.anthropic.claude-3-5-sonnet-20240620": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"apac.anthropic.claude-3-haiku-20240307":    "apac.anthropic.claude-3-haiku-20240307-v1:0",
 		//base model id
 		"claude-3-5-sonnet-20240620": "anthropic.claude-3-5-sonnet-20240620-v1:0",
 		"claude-3-5-sonnet-20241022": "anthropic.claude-3-5-sonnet-20241022-v2:0",

--- a/providers/bedrock/category/base.go
+++ b/providers/bedrock/category/base.go
@@ -20,10 +20,17 @@ type Category struct {
 
 func GetCategory(modelName string) (*Category, error) {
 	modelName = GetModelName(modelName)
+	// 获取provider
+	parts := strings.Split(modelName, ".")
+	var provider string
 
-	// 点分割
-	provider := strings.Split(modelName, ".")[0]
-
+	// 如果为cross-region取指针下标1为供应商标记
+	if len(parts) > 2 {
+		provider = parts[1]
+	} else {
+		// 否则保持原有逻辑,取第一个点前的内容
+		provider = parts[0]
+	}
 	if category, exists := CategoryMap[provider]; exists {
 		category.ModelName = modelName
 		return &category, nil
@@ -34,6 +41,22 @@ func GetCategory(modelName string) (*Category, error) {
 
 func GetModelName(modelName string) string {
 	bedrockMap := map[string]string{
+		//cross-region model id
+		"us-anthropic.claude-3-sonnet-20240229":   "us.anthropic.claude-3-sonnet-20240229-v1:0",
+		"us-anthropic.claude-3-opus-20240229":     "us.anthropic.claude-3-opus-20240229-v1:0",
+		"us-anthropic.claude-3-haiku-20240307":    "us.anthropic.claude-3-haiku-20240307-v1:0",
+		"us-anthropic.claude-3-5-sonnet-20240620": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"us-anthropic.claude-3-5-sonnet-20241022": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"us-anthropic.claude-3-5-haiku-20241022":  "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+
+		"eu-anthropic.claude-3-sonnet-20240229":   "eu.anthropic.claude-3-sonnet-20240229-v1:0",
+		"eu-anthropic.claude-3-5-sonnet-20240620": "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"eu-anthropic.claude-3-haiku-20240307":    "eu.anthropic.claude-3-haiku-20240307-v1:0",
+
+		"apac-anthropic.claude-3-sonnet-20240229":   "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+		"apac-anthropic.claude-3-5-sonnet-20240620": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+		"apac-anthropic.claude-3-haiku-20240307":    "apac.anthropic.claude-3-haiku-20240307-v1:0",
+		//base model id
 		"claude-3-5-sonnet-20240620": "anthropic.claude-3-5-sonnet-20240620-v1:0",
 		"claude-3-5-sonnet-20241022": "anthropic.claude-3-5-sonnet-20241022-v2:0",
 		"claude-3-opus-20240229":     "anthropic.claude-3-opus-20240229-v1:0",


### PR DESCRIPTION
增加aws bedrock Claude Cross-region模型支持。
参考资料：https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html

实现和配置方式：
类似`US Anthropic Claude 3 Sonnet`的Inference profile ID是`us.anthropic.claude-3-sonnet-20240229-v1:0`,后端做对应适配。在配置渠道模型的时候在原有模型名字前面以`.`分割增加区域标记us，即US Anthropic Claude 3 Sonnet的模型配置应该配置为`us.claude-3-5-sonnet-20240620`,如下图：
![image](https://github.com/user-attachments/assets/1b684eb3-c601-4e0f-b073-20e2df58a3ee)
如果需要用户请求claude-3-5-sonnet-20240620可以访问onehub的对应模型可以使用模型映射功能。

close #415

我已确认该 PR 已自测通过，相关截图如下：
![1](https://github.com/user-attachments/assets/f315cbd8-c2ce-4516-81ac-952bc630a392)
![image](https://github.com/user-attachments/assets/39ebb85f-b565-47fd-9adc-0b4270a695ce)


