### PR TITLE
Notice & i18n

### DIFF
--- a/web/src/i18n/locales/en_US.json
+++ b/web/src/i18n/locales/en_US.json
@@ -30,6 +30,7 @@
   },
   "alloy 映射": "alloy mapping",
   "analytics": "Analytics",
+  "playground": "Playground",
   "analytics_index": {
     "active": "Active",
     "averageLatency": "Average Latency",

--- a/web/src/i18n/locales/ja_JP.json
+++ b/web/src/i18n/locales/ja_JP.json
@@ -29,6 +29,7 @@
   },
   "alloy 映射": "合金マッピング",
   "analytics": "分析",
+  "playground": "遊び場",
   "analytics_index": {
     "active": "アクティブ",
     "averageLatency": "平均遅延",

--- a/web/src/i18n/locales/zh_CN.json
+++ b/web/src/i18n/locales/zh_CN.json
@@ -1,6 +1,7 @@
 {
   "dashboard": "仪表盘",
   "analytics": "分析",
+  "playground": "聊天",
   "channel": "渠道",
   "token": "令牌",
   "log": "日志",

--- a/web/src/i18n/locales/zh_HK.json
+++ b/web/src/i18n/locales/zh_HK.json
@@ -29,6 +29,7 @@
   },
   "alloy 映射": "alloy 映射",
   "analytics": "分析",
+  "plauground": "聊天",
   "analytics_index": {
     "active": "正常",
     "averageLatency": "平均延遲",

--- a/web/src/layout/MainLayout/Header/index.jsx
+++ b/web/src/layout/MainLayout/Header/index.jsx
@@ -11,6 +11,7 @@ import LogoSection from '../LogoSection';
 import ProfileSection from './ProfileSection';
 import ThemeButton from 'ui-component/ThemeButton';
 import I18nButton from 'ui-component/i18nButton';
+import NoticeButton from '../../../ui-component/NoticeButton';
 
 // assets
 // import { Icon } from '@iconify/react';
@@ -68,6 +69,7 @@ const Header = ({ handleLeftDrawerToggle }) => {
 
       <Box sx={{ flexGrow: 1 }} />
       <Box sx={{ flexGrow: 1 }} />
+      <NoticeButton />
       <ThemeButton />
       <I18nButton />
       <ProfileSection />

--- a/web/src/layout/MinimalLayout/Header/index.jsx
+++ b/web/src/layout/MinimalLayout/Header/index.jsx
@@ -82,7 +82,7 @@ const Header = () => {
             </Button>
             {account.user && (
               <Button component={Link} variant="text" to="/playground" color={pathname === '/playground' ? 'primary' : 'inherit'}>
-                Playground
+                {t('playground')}
               </Button>
             )}
             <Button component={Link} variant="text" to="/about" color={pathname === '/about' ? 'primary' : 'inherit'}>

--- a/web/src/layout/MinimalLayout/Header/index.jsx
+++ b/web/src/layout/MinimalLayout/Header/index.jsx
@@ -20,6 +20,7 @@ import { Link } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import ThemeButton from 'ui-component/ThemeButton';
+import NoticeButton from 'ui-component/NoticeButton';
 import I18nButton from 'ui-component/i18nButton';
 import ProfileSection from 'layout/MainLayout/Header/ProfileSection';
 import { IconMenu2 } from '@tabler/icons-react';
@@ -67,6 +68,7 @@ const Header = () => {
       <Stack spacing={2} direction="row" justifyContent="center" alignItems="center">
         {isMobile ? (
           <>
+            <NoticeButton />
             <ThemeButton />
             <I18nButton />
             <IconButton onClick={handleOpenMenu}>
@@ -86,6 +88,7 @@ const Header = () => {
             <Button component={Link} variant="text" to="/about" color={pathname === '/about' ? 'primary' : 'inherit'}>
               {t('menu.about')}
             </Button>
+            <NoticeButton />
             <ThemeButton />
             <I18nButton />
             {account.user ? (

--- a/web/src/menu-items/dashboard.jsx
+++ b/web/src/menu-items/dashboard.jsx
@@ -3,7 +3,7 @@ import { Icon } from '@iconify/react';
 const icons = {
   IconDashboard: () => <Icon width={20} icon="solar:widget-2-bold-duotone" />,
   IconChartHistogram: () => <Icon width={20} icon="solar:chart-2-bold-duotone" />,
-  IconBallFootball: () => <Icon width={20} icon="solar:gamepad-bold-duotone" />
+  IconBallFootball: () => <Icon width={20} icon="solar:chat-round-line-bold-duotone" />
 };
 
 const dashboard = {

--- a/web/src/ui-component/NoticeButton.jsx
+++ b/web/src/ui-component/NoticeButton.jsx
@@ -1,0 +1,53 @@
+import { useTheme } from '@mui/material/styles';
+import { Avatar, Box, ButtonBase } from '@mui/material';
+import { Icon } from '@iconify/react';
+import { marked } from 'marked';
+import { showNotice } from '../utils/common';
+
+export default function NoticeButton() {
+  const theme = useTheme();
+
+  return (
+    <Box
+      sx={{
+        ml: 2,
+        mr: 3,
+        [theme.breakpoints.down('md')]: {
+          mr: 2
+        }
+      }}
+    >
+      <ButtonBase sx={{ borderRadius: '12px' }}>
+        <Avatar
+          variant="rounded"
+          sx={{
+            ...theme.typography.commonAvatar,
+            ...theme.typography.mediumAvatar,
+            ...theme.typography.menuButton,
+            transition: 'all .2s ease-in-out',
+            borderColor: 'transparent',
+            backgroundColor: 'transparent',
+            boxShadow: 'none',
+            // color: 'inherit',
+            borderRadius: '50%',
+            '&[aria-controls="menu-list-grow"],&:hover': {
+              boxShadow: '0 0 10px rgba(0,0,0,0.2)',
+              backgroundColor: 'transparent',
+              borderRadius: '50%'
+            }
+          }}
+          onClick={() => {
+            let notice = localStorage.getItem('notice');
+            if (notice !== '') {
+              const htmlNotice = marked(notice);
+              showNotice(htmlNotice, true);
+            }
+          }}
+          color="inherit"
+        >
+          <Icon icon="lets-icons:message-duotone" width="1.3rem" />
+        </Avatar>
+      </ButtonBase>
+    </Box>
+  );
+}


### PR DESCRIPTION
1. playground改成国人熟知的“聊天”，这样更加符合目前该模块的功能属性定义
2. 增加通知重复查看按钮和功能，防止手滑关掉通知后再也找不到通知内容了

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/631b5000-a71a-4b34-b707-4d09281e51ba)
![image](https://github.com/user-attachments/assets/25a01b08-5f66-4d6f-98d5-922d70da720f)
![image](https://github.com/user-attachments/assets/24507ec0-293c-435e-ac32-234e0ba82f74)
