### PR TITLE
chore: 编辑渠道弹窗默认收起自定义参数

### DIFF
--- a/web/src/i18n/locales/en_US.json
+++ b/web/src/i18n/locales/en_US.json
@@ -88,7 +88,9 @@
     "addModelHeader": "Add Custom Header",
     "addModelMappingByJson": "Add model mapping (JSON)",
     "invalidJson": "Invalid JSON",
-    "jsonInputLabel": "JSON object, where the key is the request model and the value is the actual forwarding model."
+    "jsonInputLabel": "JSON object, where the key is the request model and the value is the actual forwarding model.",
+    "collapse": "Collapse",
+    "expand": "Expand"
   },
   "channel_index": {
     "AzureApiVersion": "Azure version number",

--- a/web/src/i18n/locales/ja_JP.json
+++ b/web/src/i18n/locales/ja_JP.json
@@ -87,7 +87,9 @@
     "addModelHeader": "カスタムヘッダーを追加",
     "addModelMappingByJson": "モデルマッピング（JSON）の追加",
     "invalidJson": "無効なJSON",
-    "jsonInputLabel": "JSONオブジェクト、キーはリクエストモデルであり、値は実際の転送モデルです。"
+    "jsonInputLabel": "JSONオブジェクト、キーはリクエストモデルであり、値は実際の転送モデルです。",
+    "collapse": "折りたたむ",
+    "expand": "展開する"
   },
   "channel_index": {
     "AzureApiVersion": "Azureのバージョン番号",

--- a/web/src/i18n/locales/zh_CN.json
+++ b/web/src/i18n/locales/zh_CN.json
@@ -159,7 +159,9 @@
     "invalidJson": "无效的JSON",
     "modelHeaderKey": "自定义Header Key",
     "modelHeaderValue": "自定义Header Value",
-    "addModelHeader": "添加自定义Header"
+    "addModelHeader": "添加自定义Header",
+    "collapse": "收起",
+    "expand": "展开"
   },
   "token_index": {
     "token": "令牌",

--- a/web/src/i18n/locales/zh_HK.json
+++ b/web/src/i18n/locales/zh_HK.json
@@ -87,7 +87,9 @@
     "requiredKey": "密鑰 不能為空",
     "requiredModels": "模型 不能為空",
     "requiredName": "名稱 不能為空",
-    "validJson": "必須是有效的JSON字符串"
+    "validJson": "必須是有效的JSON字符串",
+    "collapse": "收起",
+    "expand": "展開"
   },
   "channel_index": {
     "AzureApiVersion": "Azure 版本號",

--- a/web/src/views/Channel/component/EditModal.jsx
+++ b/web/src/views/Channel/component/EditModal.jsx
@@ -26,9 +26,13 @@ import {
   FormControlLabel,
   Typography,
   Tooltip,
+  Collapse,
+  Box,
   Chip
 } from '@mui/material';
 import LoadingButton from '@mui/lab/LoadingButton';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 
 import { Formik } from 'formik';
 import * as Yup from 'yup';
@@ -82,6 +86,7 @@ const EditModal = ({ open, channelId, onCancel, onOk, groupOptions, isTag }) => 
   const [batchAdd, setBatchAdd] = useState(false);
   const [providerModelsLoad, setProviderModelsLoad] = useState(false);
   const [hasTag, setHasTag] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   const initChannel = (typeValue) => {
     if (typeConfig[typeValue]?.inputLabel) {
@@ -917,48 +922,80 @@ const EditModal = ({ open, channelId, onCancel, onOk, groupOptions, isTag }) => 
                   const plugin = pluginList[values.type][pluginId];
                   return (
                     <>
-                      <Divider sx={{ ...theme.typography.otherInput }} />
-                      <Typography variant="h3">{customizeT(plugin.name)}</Typography>
-                      <Typography variant="caption">{customizeT(plugin.description)}</Typography>
-                      {Object.keys(plugin.params).map((paramId) => {
-                        const param = plugin.params[paramId];
-                        const name = `plugin.${pluginId}.${paramId}`;
-                        return param.type === 'bool' ? (
-                          <FormControl key={name} fullWidth sx={{ ...theme.typography.otherInput }}>
-                            <FormControlLabel
-                              key={name}
-                              required
-                              control={
-                                <Switch
-                                  key={name}
-                                  name={name}
-                                  disabled={hasTag}
-                                  checked={values.plugin?.[pluginId]?.[paramId] || false}
-                                  onChange={(event) => {
-                                    setFieldValue(name, event.target.checked);
-                                  }}
-                                />
-                              }
-                              label={t('channel_edit.isEnable')}
-                            />
-                            <FormHelperText id="helper-tex-channel-key-label"> {customizeT(param.description)} </FormHelperText>
-                          </FormControl>
-                        ) : (
-                          <FormControl key={name} fullWidth sx={{ ...theme.typography.otherInput }}>
-                            <TextField
-                              multiline
-                              key={name}
-                              name={name}
-                              disabled={hasTag}
-                              value={values.plugin?.[pluginId]?.[paramId] || ''}
-                              label={customizeT(param.name)}
-                              placeholder={customizeT(param.description)}
-                              onChange={handleChange}
-                            />
-                            <FormHelperText id="helper-tex-channel-key-label"> {customizeT(param.description)} </FormHelperText>
-                          </FormControl>
-                        );
-                      })}
+                      <Box
+                        sx={{
+                          border: '1px solid #e0e0e0',
+                          borderRadius: 2,
+                          marginTop: 2,
+                          marginBottom: 2,
+                          overflow: 'hidden'
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            padding: 2,
+                          }}
+                        >
+                          <Box sx={{ flex: 1 }}>
+                            <Typography variant="h3">{customizeT(plugin.name)}</Typography>
+                            <Typography variant="caption">{customizeT(plugin.description)}</Typography>
+                          </Box>
+                          <Button
+                            onClick={() => setExpanded(!expanded)}
+                            endIcon={expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                            sx={{ textTransform: 'none', marginLeft: 2 }}
+                          >
+                            {expanded ? t('channel_edit.collapse') : t('channel_edit.expand')}
+                          </Button>
+                        </Box>
+
+                        <Collapse in={expanded}>
+                          <Box sx={{ padding: 2, marginTop: -3 }}>
+                            {Object.keys(plugin.params).map((paramId) => {
+                              const param = plugin.params[paramId];
+                              const name = `plugin.${pluginId}.${paramId}`;
+                              return param.type === 'bool' ? (
+                                <FormControl key={name} fullWidth sx={{ ...theme.typography.otherInput }}>
+                                  <FormControlLabel
+                                    key={name}
+                                    required
+                                    control={
+                                      <Switch
+                                        key={name}
+                                        name={name}
+                                        disabled={hasTag}
+                                        checked={values.plugin?.[pluginId]?.[paramId] || false}
+                                        onChange={(event) => {
+                                          setFieldValue(name, event.target.checked);
+                                        }}
+                                      />
+                                    }
+                                    label={t('channel_edit.isEnable')}
+                                  />
+                                  <FormHelperText id="helper-tex-channel-key-label"> {customizeT(param.description)} </FormHelperText>
+                                </FormControl>
+                              ) : (
+                                <FormControl key={name} fullWidth sx={{ ...theme.typography.otherInput }}>
+                                  <TextField
+                                    multiline
+                                    key={name}
+                                    name={name}
+                                    disabled={hasTag}
+                                    value={values.plugin?.[pluginId]?.[paramId] || ''}
+                                    label={customizeT(param.name)}
+                                    placeholder={customizeT(param.description)}
+                                    onChange={handleChange}
+                                  />
+                                  <FormHelperText id="helper-tex-channel-key-label"> {customizeT(param.description)} </FormHelperText>
+                                </FormControl>
+                              );
+                            })}
+                          </Box>
+                        </Collapse>
+                      </Box>
                     </>
                   );
                 })}


### PR DESCRIPTION
创建渠道的弹窗，自定义参数太多了而且不常用，每次要多滚动一屏；改为默认收起自定义参数部分的内容，可以手动展开

我已确认该 PR 已自测通过，相关截图如下：
![PixPin_2024-12-06_20-24-56](https://github.com/user-attachments/assets/2df5f8cc-b17c-4d4a-bb37-a8a27a743701)
![PixPin_2024-12-06_20-25-32](https://github.com/user-attachments/assets/063e42fb-8cba-4fd2-abd0-c452c159d7fe)
![PixPin_2024-12-06_20-26-09](https://github.com/user-attachments/assets/fc88f939-e7e0-4a37-9979-eb046e90ee8c)
