### PR TITLE
use auto routing URL according to siliconflow support team

### DIFF
--- a/providers/siliconflow/main.go
+++ b/providers/siliconflow/main.go
@@ -33,7 +33,7 @@ type SiliconflowProvider struct {
 
 func getConfig() base.ProviderConfig {
 	return base.ProviderConfig{
-		BaseURL:             "https://api.siliconflow.cn",
+		BaseURL:             "https://api.siliconflow.com",
 		ImagesGenerations:   "/v1/%s/text-to-image",
 		ChatCompletions:     "/v1/chat/completions",
 		Embeddings:          "/v1/embeddings",


### PR DESCRIPTION
修改siliconflow api URL为api.siliconflow.com。根据硅基流动支持群消息，此url会根据请求源ip自动导向更快的服务器。已向官方确认已确认可用。
![图片](https://github.com/user-attachments/assets/094c601e-5430-470a-9357-12499ca7ec59)

