### PR TITLE
fix: 修复微信登录的报错信息提示不正确的问题

### DIFF
--- a/web/src/views/Authentication/AuthForms/WechatModal.jsx
+++ b/web/src/views/Authentication/AuthForms/WechatModal.jsx
@@ -14,8 +14,8 @@ const getValidationSchema = (t) =>
 
 const WechatModal = ({ open, handleClose, wechatLogin, qrCode }) => {
   const { t } = useTranslation();
-  const handleSubmit = (values) => {
-    const { success, message } = wechatLogin(values.code);
+  const handleSubmit = async (values) => {
+    const { success, message } = await wechatLogin(values.code);
     if (success) {
       handleClose();
     } else {


### PR DESCRIPTION
该 PR 主要修复通过微信扫码登录过程中，不管成功还是失败，都会有一个未知错误的提示，并且失败的话，没有提示具体的失败原因：

![1](https://github.com/user-attachments/assets/d2007e71-0e29-460e-835a-fd64a227756f)

我已确认该 PR 已自测通过，相关截图如下：

![2](https://github.com/user-attachments/assets/139dc0f4-b136-4a9d-ae46-6edbdc43e67b)

登录成功的场景也是正常的。