### PR TITLE
fix: 首次通过 dockerfile 构建可能会报错

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM node:16 as builder
+FROM node:18 as builder
 
 WORKDIR /build
+
 COPY web/package.json .
-RUN npm install
+COPY web/yarn.lock .
+
+RUN yarn --frozen-lockfile
+
 COPY ./web .
 COPY ./VERSION .
 RUN DISABLE_ESLINT_PLUGIN='true' VITE_APP_VERSION=$(cat VERSION) npm run build


### PR DESCRIPTION
close #474 

Dockerfile 没有拷贝lock文件，导致依赖跳版本构建报错

我已确认该 PR 已自测通过，相关截图如下：

修改Dockerfile前：

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/c3eacff0-0d01-4657-b49f-37cd98d36c03" />

修改后：

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/51227799-163b-4c47-a35d-8deb45816289" />
