### PR TITLE
feat(模型价格新增): 优化价格配置功能

### DIFF
--- a/web/src/i18n/locales/zh_CN.json
+++ b/web/src/i18n/locales/zh_CN.json
@@ -424,6 +424,8 @@
     "group": "分组",
     "inputMultiplier": "输入价格",
     "outputMultiplier": "输出价格",
+    "inputPrice": "每K输入单价（实验功能）",
+    "outputPrice": "每K输出单价（实验功能）",
     "search": "搜索",
     "tokens": "按量付费",
     "times": "按次付费",

--- a/web/src/ui-component/ToggleButton.jsx
+++ b/web/src/ui-component/ToggleButton.jsx
@@ -1,0 +1,77 @@
+import { styled } from '@mui/material';
+import { ToggleButton, ToggleButtonGroup as MuiToggleButtonGroup } from '@mui/material';
+import PropTypes from 'prop-types';
+
+const StyledToggleButtonGroup = styled(MuiToggleButtonGroup)(({ theme }) => ({
+  backgroundColor: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: '8px',
+  padding: '2px',
+  '& .MuiToggleButton-root': {
+    border: 'none',
+    borderRadius: '6px',
+    padding: '4px 12px',
+    fontSize: '13px',
+    fontWeight: 500,
+    color: theme.palette.text.secondary,
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover
+    },
+    '&.Mui-selected': {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.common.white,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.dark
+      }
+    }
+  }
+}));
+
+const StyledToggleButton = styled(ToggleButton)({
+  '&.MuiToggleButton-root': {
+    textTransform: 'none',
+    minWidth: '36px',
+    transition: 'all 0.2s ease-in-out'
+  }
+});
+
+export default function ToggleButtonGroup({
+  value,
+  onChange,
+  options = [],
+  size = 'small',
+  exclusive = true,
+  'aria-label': ariaLabel,
+  ...other
+}) {
+  const handleChange = (event, newValue) => {
+    if (newValue !== null) {
+      onChange(event, newValue);
+    }
+  };
+
+  return (
+    <StyledToggleButtonGroup value={value} exclusive={exclusive} onChange={handleChange} size={size} aria-label={ariaLabel} {...other}>
+      {options.map((option) => (
+        <StyledToggleButton key={option.value} value={option.value} disabled={option.disabled}>
+          {option.label}
+        </StyledToggleButton>
+      ))}
+    </StyledToggleButtonGroup>
+  );
+}
+
+ToggleButtonGroup.propTypes = {
+  value: PropTypes.any,
+  onChange: PropTypes.func,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.any.isRequired,
+      label: PropTypes.node.isRequired,
+      disabled: PropTypes.bool
+    })
+  ),
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  exclusive: PropTypes.bool,
+  'aria-label': PropTypes.string
+};

--- a/web/src/views/ModelPrice/index.jsx
+++ b/web/src/views/ModelPrice/index.jsx
@@ -17,9 +17,7 @@ import {
   TextField,
   InputAdornment,
   styled,
-  Box,
-  ToggleButton,
-  ToggleButtonGroup
+  Box
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { API } from 'utils/api';
@@ -27,7 +25,7 @@ import { showError, ValueFormatter } from 'utils/common';
 import { useTheme } from '@mui/material/styles';
 import IconWrapper from 'ui-component/IconWrapper';
 import Label from 'ui-component/Label';
-
+import ToggleButtonGroup from 'ui-component/ToggleButton';
 const GroupChip = styled(Chip)(({ theme, selected }) => ({
   margin: theme.spacing(0.5),
   cursor: 'pointer',
@@ -53,39 +51,6 @@ const GroupChip = styled(Chip)(({ theme, selected }) => ({
   }
 }));
 
-const StyledToggleButtonGroup = styled(ToggleButtonGroup)(({ theme }) => ({
-  backgroundColor: theme.palette.background.paper,
-  border: `1px solid ${theme.palette.divider}`,
-  borderRadius: '8px',
-  padding: '2px',
-  '& .MuiToggleButton-root': {
-    border: 'none',
-    borderRadius: '6px',
-    padding: '4px 12px',
-    fontSize: '13px',
-    fontWeight: 500,
-    color: theme.palette.text.secondary,
-    '&:hover': {
-      backgroundColor: theme.palette.action.hover
-    },
-    '&.Mui-selected': {
-      backgroundColor: theme.palette.primary.main,
-      color: theme.palette.common.white,
-      '&:hover': {
-        backgroundColor: theme.palette.primary.dark
-      }
-    }
-  }
-}));
-
-const StyledToggleButton = styled(ToggleButton)({
-  '&.MuiToggleButton-root': {
-    textTransform: 'none',
-    minWidth: '36px',
-    transition: 'all 0.2s ease-in-out'
-  }
-});
-
 // ----------------------------------------------------------------------
 export default function ModelPrice() {
   const { t } = useTranslation();
@@ -100,6 +65,11 @@ export default function ModelPrice() {
   const [selectedGroup, setSelectedGroup] = useState('');
   const [selectedOwnedBy, setSelectedOwnedBy] = useState('');
   const [unit, setUnit] = useState('K');
+
+  const unitOptions = [
+    { value: 'K', label: 'K' },
+    { value: 'M', label: 'M' }
+  ];
 
   const fetchAvailableModels = useCallback(async () => {
     try {
@@ -251,10 +221,7 @@ export default function ModelPrice() {
                 )
               }}
             />
-            <StyledToggleButtonGroup value={unit} exclusive onChange={handleUnitChange} size="small" aria-label="unit toggle">
-              <StyledToggleButton value="K">K</StyledToggleButton>
-              <StyledToggleButton value="M">M</StyledToggleButton>
-            </StyledToggleButtonGroup>
+            <ToggleButtonGroup value={unit} onChange={handleUnitChange} options={unitOptions} aria-label="unit toggle" />
           </Stack>
         </Stack>
       </Card>

--- a/web/src/views/Pricing/component/EditModal.jsx
+++ b/web/src/views/Pricing/component/EditModal.jsx
@@ -29,6 +29,7 @@ import { ValueFormatter, priceType } from './util';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
@@ -58,6 +59,19 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
   const theme = useTheme();
   const [inputs, setInputs] = useState(originInputs);
   const [selectModel, setSelectModel] = useState([]);
+
+  const [inputMultiplier, setInputMultiplier] = useState(0); // 美元输入价格状态
+  const [outputMultiplier, setOutputMultiplier] = useState(0); // 美元输出价格状态
+  const siteInfo = useSelector((state) => state.siteInfo);
+  const calculateInput = (multiplier) => {
+    // 根据输入的乘数计算输入价格
+    return (multiplier * siteInfo.quota_per_unit) / 1000;
+  };
+
+  const calculateOutput = (multiplier) => {
+    // 根据输入的乘数计算输出价格
+    return (multiplier * siteInfo.quota_per_unit) / 1000;
+  };
 
   const submit = async (values, { setErrors, setStatus, setSubmitting }) => {
     setSubmitting(true);
@@ -186,7 +200,25 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
                   </FormHelperText>
                 )}
               </FormControl>
-
+              {/* 每K输入单价（美元） */}
+              <FormControl fullWidth sx={{ ...theme.typography.otherInput }}>
+                <InputLabel htmlFor="input-multiplier-label">{t('modelpricePage.inputPrice')}</InputLabel>
+                <OutlinedInput
+                  id="input-multiplier-label"
+                  label={t('modelpricePage.inputPrice')}
+                  type="number"
+                  value={inputMultiplier}
+                  endAdornment="$"
+                  onChange={(e) => {
+                    const value = e.target.value ? Number(e.target.value) : '';
+                    setInputMultiplier(value);
+                    values.input = calculateInput(value === '' ? 0 : Number(value)); // 更新输入价格
+                  }}
+                  onBlur={handleBlur}
+                  aria-describedby="helper-text-input-multiplier-label"
+                />
+              </FormControl>
+              {/* k输入价格*/}
               <FormControl fullWidth error={Boolean(touched.input && errors.input)} sx={{ ...theme.typography.otherInput }}>
                 <InputLabel htmlFor="channel-input-label">{t('modelpricePage.inputMultiplier')}</InputLabel>
                 <OutlinedInput
@@ -208,6 +240,26 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
                 )}
               </FormControl>
 
+              {/* 每k输出单价（美元） */}
+              <FormControl fullWidth sx={{ ...theme.typography.otherInput }}>
+                <InputLabel htmlFor="output-multiplier-label">{t('modelpricePage.outputPrice')}</InputLabel>
+                <OutlinedInput
+                  id="output-multiplier-label"
+                  label={t('modelpricePage.outputPrice')}
+                  type="number"
+                  value={outputMultiplier}
+                  endAdornment="$"
+                  onChange={(e) => {
+                    const value = e.target.value ? Number(e.target.value) : '';
+                    setOutputMultiplier(value);
+                    values.output = calculateOutput(value === '' ? 0 : Number(value)); // 更新输出价格
+                  }}
+                  onBlur={handleBlur}
+                  aria-describedby="helper-text-output-multiplier-label"
+                />
+              </FormControl>
+
+              {/*k输出价格*/}
               <FormControl fullWidth error={Boolean(touched.output && errors.output)} sx={{ ...theme.typography.otherInput }}>
                 <InputLabel htmlFor="channel-output-label">{t('modelpricePage.outputMultiplier')}</InputLabel>
                 <OutlinedInput

--- a/web/src/views/Pricing/component/EditModal.jsx
+++ b/web/src/views/Pricing/component/EditModal.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import * as Yup from 'yup';
 import { Formik } from 'formik';
 import { useTheme } from '@mui/material/styles';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -19,7 +19,8 @@ import {
   Autocomplete,
   TextField,
   Checkbox,
-  MenuItem
+  MenuItem,
+  Stack
 } from '@mui/material';
 
 import { showSuccess, showError, trims } from 'utils/common';
@@ -29,7 +30,8 @@ import { ValueFormatter, priceType } from './util';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
+import ToggleButtonGroup from 'ui-component/ToggleButton';
+import Decimal from 'decimal.js';
 
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
@@ -60,14 +62,75 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
   const [inputs, setInputs] = useState(originInputs);
   const [selectModel, setSelectModel] = useState([]);
 
-  const [inputPrice, setInputPrice] = useState(0); // 美元输入价格状态
-  const [outputPrice, setOutputPrice] = useState(0); // 美元输出价格状态
-  const siteInfo = useSelector((state) => state.siteInfo);
-  const calculatePrice = (price) => {
-    // 计算价格
-    return (price * siteInfo.quota_per_unit) / 1000;
-  };
+  const [unitType, setUnitType] = useState('rate');
+  const [unit, setUnit] = useState('K');
 
+  const calculateRate = useCallback(
+    (price) => {
+      if (unitType === 'rate') {
+        return price;
+      }
+
+      let priceValue = new Decimal(price);
+
+      if (unit == 'M') {
+        priceValue = priceValue.div(1000);
+      }
+
+      switch (unitType) {
+        case 'USD':
+          priceValue = priceValue.div(0.002);
+          break;
+        case 'RMB':
+          priceValue = priceValue.div(0.014);
+          break;
+      }
+
+      return Number(priceValue.toFixed(4));
+    },
+    [unitType, unit]
+  );
+
+  const unitTypeOptions = [
+    { value: 'rate', label: '倍率' },
+    { value: 'USD', label: 'USD' },
+    { value: 'RMB', label: 'RMB' }
+  ];
+
+  const unitOptions = [
+    { value: 'K', label: 'K' },
+    { value: 'M', label: 'M' }
+  ];
+
+  const handleEndAdornment = useCallback(
+    (value) => {
+      let endAdornment = '';
+
+      switch (unitType) {
+        case 'rate':
+          endAdornment = ValueFormatter(value);
+          break;
+        case 'USD':
+        case 'RMB':
+          endAdornment = calculateRate(value);
+          break;
+      }
+
+      return endAdornment;
+    },
+    [unitType, calculateRate]
+  );
+
+  const handleStartAdornment = useCallback(() => {
+    switch (unitType) {
+      case 'rate':
+        return 'Rate：';
+      case 'USD':
+        return `USD(${unit})：`;
+      case 'RMB':
+        return `RMB(${unit})：`;
+    }
+  }, [unitType, unit]);
 
   const submit = async (values, { setErrors, setStatus, setSubmitting }) => {
     setSubmitting(true);
@@ -80,8 +143,8 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
           model: 'batch',
           type: values.type,
           channel_type: values.channel_type,
-          input: values.input,
-          output: values.output
+          input: calculateRate(values.input),
+          output: calculateRate(values.output)
         }
       });
       const { success, message } = res.data;
@@ -196,24 +259,29 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
                   </FormHelperText>
                 )}
               </FormControl>
-              {/* 每K输入单价（美元） */}
+
               <FormControl fullWidth sx={{ ...theme.typography.otherInput }}>
-                <InputLabel htmlFor="input-multiplier-label">{t('modelpricePage.inputPrice')}</InputLabel>
-                <OutlinedInput
-                  id="input-multiplier-label"
-                  label={t('modelpricePage.inputPrice')}
-                  type="number"
-                  value={inputPrice}
-                  endAdornment="$"
-                  onChange={(e) => {
-                    const value = e.target.value ? Number(e.target.value) : '';
-                    setInputPrice(value);
-                    values.input = calculatePrice(value === '' ? 0 : Number(value)); // 更新输入价格
-                  }}
-                  onBlur={handleBlur}
-                  aria-describedby="helper-text-input-multiplier-label"
-                />
+                <Stack direction="row" spacing={2}>
+                  <ToggleButtonGroup
+                    value={unitType}
+                    onChange={(event, newUnitType) => {
+                      setUnitType(newUnitType);
+                    }}
+                    options={unitTypeOptions}
+                    aria-label="unit toggle"
+                  />
+
+                  <ToggleButtonGroup
+                    value={unit}
+                    onChange={(event, newUnit) => {
+                      setUnit(newUnit);
+                    }}
+                    options={unitOptions}
+                    aria-label="unit toggle"
+                  />
+                </Stack>
               </FormControl>
+
               <FormControl fullWidth error={Boolean(touched.input && errors.input)} sx={{ ...theme.typography.otherInput }}>
                 <InputLabel htmlFor="channel-input-label">{t('modelpricePage.inputMultiplier')}</InputLabel>
                 <OutlinedInput
@@ -222,7 +290,8 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
                   type="number"
                   value={values.input}
                   name="input"
-                  endAdornment={<InputAdornment position="end">{ValueFormatter(values.input)}</InputAdornment>}
+                  startAdornment={handleStartAdornment()}
+                  endAdornment={<InputAdornment position="end">{handleEndAdornment(values.input)}</InputAdornment>}
                   onBlur={handleBlur}
                   onChange={handleChange}
                   aria-describedby="helper-text-channel-input-label"
@@ -235,24 +304,6 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
                 )}
               </FormControl>
 
-              {/* 每k输出单价（美元） */}
-              <FormControl fullWidth sx={{ ...theme.typography.otherInput }}>
-                <InputLabel htmlFor="output-multiplier-label">{t('modelpricePage.outputPrice')}</InputLabel>
-                <OutlinedInput
-                  id="output-multiplier-label"
-                  label={t('modelpricePage.outputPrice')}
-                  type="number"
-                  value={outputPrice}
-                  endAdornment="$"
-                  onChange={(e) => {
-                    const value = e.target.value ? Number(e.target.value) : '';
-                    setOutputPrice(value);
-                    values.output = calculatePrice(value === '' ? 0 : Number(value)); // 更新输出价格
-                  }}
-                  onBlur={handleBlur}
-                  aria-describedby="helper-text-output-multiplier-label"
-                />
-              </FormControl>
               <FormControl fullWidth error={Boolean(touched.output && errors.output)} sx={{ ...theme.typography.otherInput }}>
                 <InputLabel htmlFor="channel-output-label">{t('modelpricePage.outputMultiplier')}</InputLabel>
                 <OutlinedInput
@@ -261,7 +312,8 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
                   type="number"
                   value={values.output}
                   name="output"
-                  endAdornment={<InputAdornment position="end">{ValueFormatter(values.output)}</InputAdornment>}
+                  startAdornment={handleStartAdornment()}
+                  endAdornment={<InputAdornment position="end">{handleEndAdornment(values.output)}</InputAdornment>}
                   onBlur={handleBlur}
                   onChange={handleChange}
                   aria-describedby="helper-text-channel-output-label"

--- a/web/src/views/Pricing/component/EditModal.jsx
+++ b/web/src/views/Pricing/component/EditModal.jsx
@@ -60,18 +60,14 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
   const [inputs, setInputs] = useState(originInputs);
   const [selectModel, setSelectModel] = useState([]);
 
-  const [inputMultiplier, setInputMultiplier] = useState(0); // 美元输入价格状态
-  const [outputMultiplier, setOutputMultiplier] = useState(0); // 美元输出价格状态
+  const [inputPrice, setInputPrice] = useState(0); // 美元输入价格状态
+  const [outputPrice, setOutputPrice] = useState(0); // 美元输出价格状态
   const siteInfo = useSelector((state) => state.siteInfo);
-  const calculateInput = (multiplier) => {
-    // 根据输入的乘数计算输入价格
-    return (multiplier * siteInfo.quota_per_unit) / 1000;
+  const calculatePrice = (price) => {
+    // 计算价格
+    return (price * siteInfo.quota_per_unit) / 1000;
   };
 
-  const calculateOutput = (multiplier) => {
-    // 根据输入的乘数计算输出价格
-    return (multiplier * siteInfo.quota_per_unit) / 1000;
-  };
 
   const submit = async (values, { setErrors, setStatus, setSubmitting }) => {
     setSubmitting(true);
@@ -207,18 +203,17 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
                   id="input-multiplier-label"
                   label={t('modelpricePage.inputPrice')}
                   type="number"
-                  value={inputMultiplier}
+                  value={inputPrice}
                   endAdornment="$"
                   onChange={(e) => {
                     const value = e.target.value ? Number(e.target.value) : '';
-                    setInputMultiplier(value);
-                    values.input = calculateInput(value === '' ? 0 : Number(value)); // 更新输入价格
+                    setInputPrice(value);
+                    values.input = calculatePrice(value === '' ? 0 : Number(value)); // 更新输入价格
                   }}
                   onBlur={handleBlur}
                   aria-describedby="helper-text-input-multiplier-label"
                 />
               </FormControl>
-              {/* k输入价格*/}
               <FormControl fullWidth error={Boolean(touched.input && errors.input)} sx={{ ...theme.typography.otherInput }}>
                 <InputLabel htmlFor="channel-input-label">{t('modelpricePage.inputMultiplier')}</InputLabel>
                 <OutlinedInput
@@ -247,19 +242,17 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
                   id="output-multiplier-label"
                   label={t('modelpricePage.outputPrice')}
                   type="number"
-                  value={outputMultiplier}
+                  value={outputPrice}
                   endAdornment="$"
                   onChange={(e) => {
                     const value = e.target.value ? Number(e.target.value) : '';
-                    setOutputMultiplier(value);
-                    values.output = calculateOutput(value === '' ? 0 : Number(value)); // 更新输出价格
+                    setOutputPrice(value);
+                    values.output = calculatePrice(value === '' ? 0 : Number(value)); // 更新输出价格
                   }}
                   onBlur={handleBlur}
                   aria-describedby="helper-text-output-multiplier-label"
                 />
               </FormControl>
-
-              {/*k输出价格*/}
               <FormControl fullWidth error={Boolean(touched.output && errors.output)} sx={{ ...theme.typography.otherInput }}>
                 <InputLabel htmlFor="channel-output-label">{t('modelpricePage.outputMultiplier')}</InputLabel>
                 <OutlinedInput


### PR DESCRIPTION
增加每K价格到倍率的自动换算功能，新增模型价格的时候可以输入每K的价格（美元）自动换算成系统倍率。


我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/c0258aac-2263-4b32-a21d-442ab9b4bfb8)
![image](https://github.com/user-attachments/assets/e7be3904-f8b4-4ed5-8e8b-bd7da36dad3c)
![image](https://github.com/user-attachments/assets/cf5c3789-9ef8-44d7-98a1-86be1ff62cc3)
