### PR TITLE
fix(模型价格): 修复模型价格增删页面崩溃问题

### DIFF
--- a/web/src/views/Pricing/component/EditModal.jsx
+++ b/web/src/views/Pricing/component/EditModal.jsx
@@ -67,6 +67,9 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
 
   const calculateRate = useCallback(
     (price) => {
+      if(price===''){
+        return 0;
+      }
       if (unitType === 'rate') {
         return price;
       }
@@ -112,7 +115,7 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
           break;
         case 'USD':
         case 'RMB':
-          endAdornment = calculateRate(value);
+          endAdornment = value===0?'Free':calculateRate(value)+" Rate";
           break;
       }
 

--- a/web/src/views/Pricing/component/EditModal.jsx
+++ b/web/src/views/Pricing/component/EditModal.jsx
@@ -67,7 +67,7 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
 
   const calculateRate = useCallback(
     (price) => {
-      if(price===''){
+      if (price === '') {
         return 0;
       }
       if (unitType === 'rate') {
@@ -76,7 +76,7 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
 
       let priceValue = new Decimal(price);
 
-      if (unit == 'M') {
+      if (unit === 'M') {
         priceValue = priceValue.div(1000);
       }
 
@@ -115,7 +115,7 @@ const EditModal = ({ open, pricesItem, onCancel, onOk, ownedby, noPriceModel }) 
           break;
         case 'USD':
         case 'RMB':
-          endAdornment = value===0?'Free':calculateRate(value)+" Rate";
+          endAdornment = value === 0 ? 'Free' : calculateRate(value) + ' Rate';
           break;
       }
 

--- a/web/src/views/Pricing/component/util.js
+++ b/web/src/views/Pricing/component/util.js
@@ -8,7 +8,7 @@ export function ValueFormatter(value) {
     return '';
   }
   if (value === 0) {
-    return '免费';
+    return 'Free';
   }
   return `$${parseFloat(value * 0.002).toFixed(6)} / ￥${parseFloat(value * 0.014).toFixed(6)}`;
 }


### PR DESCRIPTION
1. 修复模型价格增删面板当选择计算方式为法币时输入框为空崩溃的问题。
2. 一些简单体验的调整优化


我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/ecf8f870-2eb0-4671-9bc5-52f75bcb7fa6)
