### PR TITLE
fix(user): remove user group filter

### DIFF
--- a/web/src/views/Token/index.jsx
+++ b/web/src/views/Token/index.jsx
@@ -111,9 +111,7 @@ export default function Token() {
   useEffect(() => {
     let options = [];
     Object.values(userGroup).forEach((item) => {
-      if (item.public) {
-        options.push({ label: `${item.name} (倍率：${item.ratio})`, value: item.symbol });
-      }
+      options.push({ label: `${item.name} (倍率：${item.ratio})`, value: item.symbol });
     });
     setUserGroupOptions(options);
   }, [userGroup]);


### PR DESCRIPTION
后端实际已经对 API 能够获取到的用户组进行了筛选，只会返回用户当前用户组或者公开用户组，前端再次筛选会导致用户看不到非公开但是自己有权限的用户组

```go
// controller/group.go:26

UserGroup := make(map[string]*model.UserGroup)
for k, v := range groupRatio {
  if v.Public || k == userSymbol {
    UserGroup[k] = v
  }
}
```

我已确认该 PR 已自测通过，相关截图如下：

<img width="902" alt="image" src="https://github.com/user-attachments/assets/393a7f21-a558-49b4-9fa2-f0b61b10ebf9" />

