### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget -q -O - http://localhost:3000/api/status | grep -o '\"success\":\\s*true' | awk -F: '{print $2}'",
+          "wget -q -O - http://localhost:3000/api/status | grep -o '\"success\":\\s*true' | awk -F: '{print $$2}'",
         ]
       interval: 30s
       timeout: 10s


### PR DESCRIPTION
此处,当遇到 $2 时，它会尝试将其作为环境变量解析，但因为 $2 不是合法的插值格式，所以报错。为了解决这个问题，你需要将 $ 符号进行转义，使用 $$ 来表示字面上的 $。

![image](https://github.com/user-attachments/assets/ab1ec651-03c0-479a-93bc-6f7a95d6f1b4)


我已确认该 PR 已自测通过，相关截图如下：
