### PR TITLE
Update default baseURL for Github Model

### DIFF
--- a/providers/github/base.go
+++ b/providers/github/base.go
@@ -26,7 +26,7 @@ func (f GithubProviderFactory) Create(channel *model.Channel) base.ProviderInter
 
 func getGithubConfig() base.ProviderConfig {
 	return base.ProviderConfig{
-		BaseURL:         "https://models.inference.ai.azure.com",
+		BaseURL:         "https://models.github.ai/inference",
 		ChatCompletions: "/chat/completions",
 		Embeddings:      "/embeddings",
 	}

--- a/web/src/views/Channel/type/Config.js
+++ b/web/src/views/Channel/type/Config.js
@@ -460,7 +460,7 @@ const typeConfig = {
     },
     prompt: {
       key: '密钥信息请参考https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens',
-      base_url: 'https://models.inference.ai.azure.com'
+      base_url: 'https://models.github.ai/inference'
     },
     modelGroup: 'Github'
   },


### PR DESCRIPTION
The baseURL for GitHub Model has been changed to "https://models.github.ai/inference"