### PR TITLE
feat(thinking): support for openrouter thinking param

### DIFF
--- a/types/chat.go
+++ b/types/chat.go
@@ -52,6 +52,7 @@ type ChatCompletionMessage struct {
 	ToolCalls        []*ChatCompletionToolCalls       `json:"tool_calls,omitempty"`
 	ToolCallID       string                           `json:"tool_call_id,omitempty"`
 	Audio            any                              `json:"audio,omitempty"`
+	Reasoning        string                           `json:"reasoning,omitempty"`
 }
 
 func (m ChatCompletionMessage) StringContent() string {
@@ -215,8 +216,8 @@ type ChatCompletionRequest struct {
 	Audio               *ChatAudio                    `json:"audio,omitempty"`
 	ReasoningEffort     *string                       `json:"reasoning_effort,omitempty"`
 	Prediction          any                           `json:"prediction,omitempty"`
-
-	OneOtherArg string `json:"-"`
+	IncludeReasoning    bool                          `json:"include_reasoning,omitempty"`
+	OneOtherArg         string                        `json:"-"`
 }
 
 func (r ChatCompletionRequest) ParseToolChoice() (toolType, toolFunc string) {
@@ -391,6 +392,7 @@ type ChatCompletionStreamChoiceDelta struct {
 	FunctionCall     *ChatCompletionToolCallsFunction `json:"function_call,omitempty"`
 	ToolCalls        []*ChatCompletionToolCalls       `json:"tool_calls,omitempty"`
 	ReasoningContent string                           `json:"reasoning_content,omitempty"`
+	Reasoning        string                           `json:"reasoning,omitempty"`
 }
 
 func (m *ChatCompletionStreamChoiceDelta) ToolToFuncCalls() {


### PR DESCRIPTION
close #518 

我已确认该 PR 已自测通过，相关截图如下：

### 非流式响应：

<img width="1096" alt="iShot_2025-02-26_11 39 57" src="https://github.com/user-attachments/assets/42bf39c7-5749-411d-9be7-6e04e8a853eb" />

### 流式响应：

<img width="1119" alt="iShot_2025-02-26_11 51 49" src="https://github.com/user-attachments/assets/e126047c-2d0d-4ca3-b2f3-be417cc2b015" />

