### PR TITLE
style(日志): 优化日志显示

### DIFF
--- a/web/src/i18n/locales/en_US.json
+++ b/web/src/i18n/locales/en_US.json
@@ -281,7 +281,10 @@
       "original_output_price": "Original output price: ${{ price }} /M",
       "original_times_price": "Original price: ${{ times }} per time",
       "output_price": "Output: ${{ price }} /M",
-      "times_price": "${{ times }} / time"
+      "times_price": "${{ times }} / time",
+      "free": "Free",
+      "old_log": "old version log",
+      "illustrate": "* This record is the log recorded before the system upgrade"
     },
     "cachedReadTokens": "Cache read Tokens",
     "cachedWriteTokens": "Write tokens to cache (* {{ ratio }})"

--- a/web/src/i18n/locales/ja_JP.json
+++ b/web/src/i18n/locales/ja_JP.json
@@ -281,7 +281,10 @@
       "original_output_price": "元の出力価格：${{ price }}/M",
       "original_times_price": "元の価格：${{ times }} / 回",
       "output_price": "出力: ${{ price }} /M",
-      "times_price": "${{ times }} / 回"
+      "times_price": "${{ times }} / 回",
+      "free": "無料",
+      "old_log": "旧バージョンのログ",
+      "illustrate": "* この記録はシステムアップグレード前のログであり"
     },
     "cachedReadTokens": "キャッシュからトークンを読み取ります（* {{ ratio }} )",
     "cachedWriteTokens": "トークンのキャッシュ書き込み（* {{ ratio }} ）"

--- a/web/src/i18n/locales/zh_CN.json
+++ b/web/src/i18n/locales/zh_CN.json
@@ -234,7 +234,10 @@
       "original_output_price": "原输出价格: ${{ price }} /M",
       "original_times_price": "原价格: ${{ times }} / 次",
       "calculate_steps": "计算步骤: ",
-      "calculate_steps_tip": "PS：本系统按照积分计算，所有金额均为积分换算而来，1积分=$0.000002，最低消费为1积分，本计算步骤仅供参考，以实际扣费为准"
+      "calculate_steps_tip": "PS：本系统按照积分计算，所有金额均为积分换算而来，1积分=$0.000002，最低消费为1积分，本计算步骤仅供参考，以实际扣费为准",
+      "free": "免费",
+      "old_log": "旧版记录",
+      "illustrate": "* 本条记录为系统升级前所记录的log"
     }
   },
   "redemptionPage": {

--- a/web/src/i18n/locales/zh_HK.json
+++ b/web/src/i18n/locales/zh_HK.json
@@ -282,7 +282,10 @@
       "original_output_price": "原輸出價格: ${{ price }} /M",
       "original_times_price": "原價格: ${{ times }} / 次",
       "output_price": "輸出: ${{ price }} /M",
-      "times_price": "${{ times }} / 次"
+      "times_price": "${{ times }} / 次",
+      "free":"免費",
+      "old_log": "舊版log",
+      "illustrate": "* 本筆記錄為系統升級前所記錄的log"
     },
     "cachedReadTokens": "緩存讀取Tokens",
     "cachedWriteTokens": "緩存寫入 Tokens"

--- a/web/src/views/Log/component/TableRow.jsx
+++ b/web/src/views/Log/component/TableRow.jsx
@@ -289,9 +289,27 @@ function calculateTokens(item) {
 
 function viewLogContent(item, t, totalInputTokens, totalOutputTokens) {
   if (!item?.metadata?.input_ratio) {
-    return item.content;
+    let free = false;
+    if (item.quota === 0) {
+      free = true;
+    }
+    const tips = (
+      <>
+        <MetadataTypography>{item.content}</MetadataTypography>
+        {item.quota !== 0 && <MetadataTypography>{t('logPage.content.illustrate')}</MetadataTypography>}
+        <MetadataTypography>{t('logPage.content.calculate_steps_tip')}</MetadataTypography>
+      </>
+    );
+    return (
+      <Tooltip title={tips} placement="top" arrow>
+        <Stack direction="column" spacing={0.3}>
+          <Label color={free ? 'success' : 'secondary'} variant="soft">
+            {free ? t('logPage.content.free') : t('logPage.content.old_log')}
+          </Label>
+        </Stack>
+      </Tooltip>
+    );
   }
-
   const groupDiscount = item?.metadata?.group_ratio || 1;
 
   const priceType = item?.metadata?.price_type;


### PR DESCRIPTION
优化日志详情显示方式
- 对于0费记录在详情显示免费标记而不是展示0费费率
- 对于非0费记录的老版本记录做单独展示

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/aa356b1b-b027-4b66-9fc1-658d28b74542)
![image](https://github.com/user-attachments/assets/669785ea-805e-49d1-a97f-ee326ca4fbaf)
![image](https://github.com/user-attachments/assets/53ed374b-1704-4a63-83d4-0a120b4c9ae0)
