### PR TITLE
fix(Gemini): Gemini代理异常解决

### DIFF
--- a/providers/gemini/relay.go
+++ b/providers/gemini/relay.go
@@ -95,13 +95,13 @@ func (h *GeminiRelayStreamHandler) HandlerStream(rawLine *[]byte, dataChan chan 
 		return
 	}
 
-	if geminiResponse.UsageMetadata == nil || geminiResponse.Candidates[0].Content.Parts[0].CodeExecutionResult != nil {
+	if geminiResponse.UsageMetadata == nil || (len(geminiResponse.Candidates[0].Content.Parts) > 0 && geminiResponse.Candidates[0].Content.Parts[0].CodeExecutionResult != nil) {
 		dataChan <- rawStr
 		return
 	}
 
 	lastType := "text"
-	if geminiResponse.Candidates[0].Content.Parts[0].ExecutableCode != nil {
+	if len(geminiResponse.Candidates[0].Content.Parts) > 0 && geminiResponse.Candidates[0].Content.Parts[0].ExecutableCode != nil {
 		lastType = "code"
 	}
 	if h.LastType != lastType {

--- a/providers/gemini/type.go
+++ b/providers/gemini/type.go
@@ -183,7 +183,7 @@ func (g *GeminiFunctionCall) ToOpenAITool() *types.ChatCompletionToolCalls {
 
 type GeminiChatContent struct {
 	Role  string       `json:"role,omitempty"`
-	Parts []GeminiPart `json:"parts"`
+	Parts []GeminiPart `json:"parts,omitempty"`
 }
 
 type GeminiChatSafetySettings struct {

--- a/providers/siliconflow/main.go
+++ b/providers/siliconflow/main.go
@@ -33,7 +33,7 @@ type SiliconflowProvider struct {
 
 func getConfig() base.ProviderConfig {
 	return base.ProviderConfig{
-		BaseURL:             "https://api.siliconflow.com",
+		BaseURL:             "https://api.siliconflow.cn",
 		ImagesGenerations:   "/v1/%s/text-to-image",
 		ChatCompletions:     "/v1/chat/completions",
 		Embeddings:          "/v1/embeddings",

--- a/web/src/views/Channel/type/Config.js
+++ b/web/src/views/Channel/type/Config.js
@@ -437,13 +437,15 @@ const typeConfig = {
   },
   45: {
     input: {
+      base_url: 'https://api.siliconflow.cn',
       models: ['black-forest-labs/FLUX.1-dev', 'black-forest-labs/FLUX.1-schnell']
     },
     inputLabel: {
+      base_url: '渠道API地址',
       provider_models_list: '从Siliconflow获取模型列表'
     },
     prompt: {
-      base_url: ''
+      base_url: '官方api地址https://api.siliconflow.com即将停用，请使用https://api.siliconflow.cn'
     },
     modelGroup: 'Siliconflow'
   },

--- a/web/src/views/Channel/type/Config.js
+++ b/web/src/views/Channel/type/Config.js
@@ -437,7 +437,7 @@ const typeConfig = {
   },
   45: {
     input: {
-      base_url: 'https://api.siliconflow.cn',
+      base_url: '',
       models: ['black-forest-labs/FLUX.1-dev', 'black-forest-labs/FLUX.1-schnell']
     },
     inputLabel: {


### PR DESCRIPTION
Gemini渠道`content`里的`parts`可能不存在，比如最后STOP的时候就没有`parts`，所以需要单独判断parts有没有子集然后再取子集
