### PR TITLE
解决了 OpenAI 格式图像生成 API，当模型名称不是 dall-e-2 或 dall-e-3 时无法正常使用的问题。

### DIFF
--- a/providers/openai/image_generations.go
+++ b/providers/openai/image_generations.go
@@ -43,7 +43,7 @@ func (p *OpenAIProvider) CreateImageGenerations(request *types.ImageRequest) (*t
 
 func IsWithinRange(element string, value int) bool {
 	if _, ok := common.DalleGenerationImageAmounts[element]; !ok {
-		return false
+		return true
 	}
 	minCount := common.DalleGenerationImageAmounts[element][0]
 	maxCount := common.DalleGenerationImageAmounts[element][1]

--- a/relay/image-generations.go
+++ b/relay/image-generations.go
@@ -5,7 +5,7 @@ import (
 	"one-api/common"
 	providersBase "one-api/providers/base"
 	"one-api/types"
-
+	"strings"
 	"github.com/gin-gonic/gin"
 )
 
@@ -33,12 +33,14 @@ func (r *relayImageGenerations) setRequest() error {
 		r.request.N = 1
 	}
 
-	if r.request.Size == "" {
-		r.request.Size = "1024x1024"
-	}
+	if strings.HasPrefix(r.request.Model, "dall-e") {
+		if r.request.Size == "" {
+			r.request.Size = "1024x1024"
+		}
 
-	if r.request.Quality == "" {
-		r.request.Quality = "standard"
+		if r.request.Quality == "" {
+			r.request.Quality = "standard"
+		}
 	}
 
 	r.setOriginalModel(r.request.Model)


### PR DESCRIPTION
解决了 OpenAI 格式图像生成 API，当模型名称不是 dall-e-2 或 dall-e-3 时无法正常使用的问题。

close #565
