### PR TITLE
使可用模型标签的UI与整体一致

### DIFF
--- a/web/src/views/Channel/component/TableRow.jsx
+++ b/web/src/views/Channel/component/TableRow.jsx
@@ -708,7 +708,7 @@ export default function ChannelTableRow({ item, manageChannel, onRefresh, groupO
                     sx={{
                       fontWeight: 600,
                       color: 'text.secondary',
-                      mr: 1,
+                      // mr: 1,
                       display: 'flex',
                       alignItems: 'center'
                     }}
@@ -721,11 +721,11 @@ export default function ChannelTableRow({ item, manageChannel, onRefresh, groupO
                       color="primary"
                       key={model}
                       sx={{
-                        py: 0.75,
-                        px: 1.5,
+                        // py: 0.75,
+                        // px: 1.5,
                         fontSize: '0.75rem',
                         cursor: 'pointer',
-                        '&:hover': { opacity: 0.8 }
+                        // '&:hover': { opacity: 0.8 }
                       }}
                       onClick={() => {
                         copy(model, t('channel_index.modelName'));


### PR DESCRIPTION
[//]: # "请按照以下格式关联 issue"
[//]: # "请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢"
[//]: # "项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解"
[//]: # "请在提交 PR 之前删除上面的注释"

我已确认该 PR 已自测通过，相关截图如下：
原来：
![image](https://github.com/user-attachments/assets/dacba0c7-9635-443f-a4a8-a76226011ea5)
现在：
![3c9f320c0cb7946c8986429fda042650](https://github.com/user-attachments/assets/83fb44f0-00c0-46b4-ab09-fec3b92da029)

使得“可用模型”标签与“测速模型”标签以及仪表盘“当前可用模型”标签的样式保持一致。