### PR TITLE
添加页面大小管理功能，支持从 localStorage 获取和保存页面大小

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,4 @@
+.env
+config.yaml
+one-api.db
+node_modules/

--- a/web/src/constants/CommonConstants.js
+++ b/web/src/constants/CommonConstants.js
@@ -1,2 +1,46 @@
 export const ITEMS_PER_PAGE = 10; // this value must keep same as the one defined in backend!
 export const PAGE_SIZE_OPTIONS = [10, 30, 50, 100];
+
+// 页面分页大小本地存储键
+const PAGE_SIZE_STORAGE_KEY = 'user_page_sizes';
+
+/**
+ * 从localStorage获取页面大小
+ * @param {string} pageKey - 页面唯一标识
+ * @param {number} defaultSize - 默认页面大小
+ * @returns {number} - 页面大小
+ */
+export const getPageSize = (pageKey, defaultSize = ITEMS_PER_PAGE) => {
+  try {
+    const pageSizesStr = localStorage.getItem(PAGE_SIZE_STORAGE_KEY);
+    if (pageSizesStr) {
+      const pageSizes = JSON.parse(pageSizesStr);
+      if (pageSizes[pageKey] !== undefined) {
+        return parseInt(pageSizes[pageKey], 10);
+      }
+    }
+    return defaultSize;
+  } catch (error) {
+    console.error('get page size error:', error);
+    return defaultSize;
+  }
+};
+
+/**
+ * 保存页面大小到localStorage
+ * @param {string} pageKey - 页面唯一标识
+ * @param {number} size - 页面大小
+ */
+export const savePageSize = (pageKey, size) => {
+  try {
+    let pageSizes = {};
+    const pageSizesStr = localStorage.getItem(PAGE_SIZE_STORAGE_KEY);
+    if (pageSizesStr) {
+      pageSizes = JSON.parse(pageSizesStr);
+    }
+    pageSizes[pageKey] = size;
+    localStorage.setItem(PAGE_SIZE_STORAGE_KEY, JSON.stringify(pageSizes));
+  } catch (error) {
+    console.error('save page size error:', error);
+  }
+};

--- a/web/src/constants/CommonConstants.js
+++ b/web/src/constants/CommonConstants.js
@@ -21,7 +21,7 @@ export const getPageSize = (pageKey, defaultSize = ITEMS_PER_PAGE) => {
     }
     return defaultSize;
   } catch (error) {
-    console.error('get page size error:', error);
+    console.error('Error while getting page size:', error);
     return defaultSize;
   }
 };
@@ -36,11 +36,22 @@ export const savePageSize = (pageKey, size) => {
     let pageSizes = {};
     const pageSizesStr = localStorage.getItem(PAGE_SIZE_STORAGE_KEY);
     if (pageSizesStr) {
-      pageSizes = JSON.parse(pageSizesStr);
+      try {
+        pageSizes = JSON.parse(pageSizesStr);
+      } catch (parseError) {
+        console.error('Failed to parse page size data from localStorage, resetting data:', parseError);
+      }
     }
     pageSizes[pageKey] = size;
     localStorage.setItem(PAGE_SIZE_STORAGE_KEY, JSON.stringify(pageSizes));
   } catch (error) {
-    console.error('save page size error:', error);
+    console.error('Error while saving page size:', error);
+    try {
+      const singlePageData = {};
+      singlePageData[pageKey] = size;
+      localStorage.setItem(PAGE_SIZE_STORAGE_KEY, JSON.stringify(singlePageData));
+    } catch (fallbackError) {
+      console.error('Failed to save single page size settings:', fallbackError);
+    }
   }
 };

--- a/web/src/views/Channel/component/ChannelTable.jsx
+++ b/web/src/views/Channel/component/ChannelTable.jsx
@@ -9,7 +9,7 @@ import TablePagination from '@mui/material/TablePagination';
 import LinearProgress from '@mui/material/LinearProgress';
 import ChannelTableRow from './TableRow';
 import KeywordTableHead from 'ui-component/TableHead';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import { fetchChannelData } from '../ChannelList';
 import { API } from 'utils/api';
 import { showError, showSuccess, trims } from 'utils/common';
@@ -20,7 +20,7 @@ export default function ChannelTable({ tag }) {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('id');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('channelTag'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [channels, setChannels] = useState([]);
@@ -39,8 +39,10 @@ export default function ChannelTable({ tag }) {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('channelTag', newRowsPerPage);
   };
 
   // 处理刷新

--- a/web/src/views/Channel/index.jsx
+++ b/web/src/views/Channel/index.jsx
@@ -18,7 +18,7 @@ import ChannelTableRow from './component/TableRow';
 import KeywordTableHead from 'ui-component/TableHead';
 import { API } from 'utils/api';
 import EditeModal from './component/EditModal';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import TableToolBar from './component/TableToolBar';
 import BatchModal from './component/BatchModal';
 import { useTranslation } from 'react-i18next';
@@ -73,7 +73,7 @@ export default function ChannelList() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('id');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('channel'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [channels, setChannels] = useState([]);
@@ -108,8 +108,10 @@ export default function ChannelList() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('channel', newRowsPerPage);
   };
 
   const searchChannels = async () => {

--- a/web/src/views/Log/index.jsx
+++ b/web/src/views/Log/index.jsx
@@ -17,7 +17,7 @@ import KeywordTableHead from 'ui-component/TableHead';
 import TableToolBar from './component/TableToolBar';
 import { API } from 'utils/api';
 import { isAdmin } from 'utils/common';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import { Icon } from '@iconify/react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
@@ -42,7 +42,7 @@ export default function Log() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('created_at');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('log'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [toolBarValue, setToolBarValue] = useState(originalKeyword);
@@ -116,8 +116,10 @@ export default function Log() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('log', newRowsPerPage);
   };
 
   const searchLogs = async () => {

--- a/web/src/views/Midjourney/index.jsx
+++ b/web/src/views/Midjourney/index.jsx
@@ -16,7 +16,7 @@ import KeywordTableHead from 'ui-component/TableHead';
 import TableToolBar from './component/TableToolBar';
 import { API } from 'utils/api';
 import { isAdmin } from 'utils/common';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import { Icon } from '@iconify/react';
 import dayjs from 'dayjs';
 
@@ -34,7 +34,7 @@ export default function Log() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('id');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('midjourney'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [toolBarValue, setToolBarValue] = useState(originalKeyword);
@@ -57,8 +57,10 @@ export default function Log() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('midjourney', newRowsPerPage);
   };
 
   const searchLogs = async () => {

--- a/web/src/views/Payment/Gateway.jsx
+++ b/web/src/views/Payment/Gateway.jsx
@@ -16,7 +16,7 @@ import KeywordTableHead from 'ui-component/TableHead';
 import TableToolBar from './component/TableToolBar';
 import EditeModal from './component/EditModal';
 import { API } from 'utils/api';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import { Icon } from '@iconify/react';
 
 export default function Gateway() {
@@ -33,7 +33,7 @@ export default function Gateway() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('created_at');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('paymentGateway'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [toolBarValue, setToolBarValue] = useState(originalKeyword);
@@ -74,8 +74,10 @@ export default function Gateway() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('paymentGateway', newRowsPerPage);
   };
 
   const search = async () => {

--- a/web/src/views/Payment/Order.jsx
+++ b/web/src/views/Payment/Order.jsx
@@ -15,7 +15,7 @@ import LogTableRow from './component/OrderTableRow';
 import KeywordTableHead from 'ui-component/TableHead';
 import TableToolBar from './component/OrderTableToolBar';
 import { API } from 'utils/api';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import { Icon } from '@iconify/react';
 import dayjs from 'dayjs';
 
@@ -35,7 +35,7 @@ export default function Order() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('created_at');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('paymentOrder'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [toolBarValue, setToolBarValue] = useState(originalKeyword);
@@ -57,8 +57,10 @@ export default function Order() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('paymentOrder', newRowsPerPage);
   };
 
   const searchLogs = async () => {

--- a/web/src/views/Pricing/single.jsx
+++ b/web/src/views/Pricing/single.jsx
@@ -21,6 +21,7 @@ import { showError, showSuccess, trims } from 'utils/common';
 import { API } from 'utils/api';
 import { ValueFormatter, priceType } from './component/util';
 import { useTranslation } from 'react-i18next';
+import { getPageSize, savePageSize } from 'constants';
 
 function validation(t, row, rows) {
   if (row.model === '') {
@@ -328,8 +329,11 @@ const Single = ({ ownedby, prices, reloadData }) => {
         rows={rows}
         columns={modelRatioColumns}
         editMode="row"
-        initialState={{ pagination: { paginationModel: { pageSize: 20 } } }}
+        initialState={{ pagination: { paginationModel: { pageSize: getPageSize('pricing', 20) }}}}
         pageSizeOptions={[20, 30, 50, 100]}
+        onPaginationModelChange={(model) => {
+          savePageSize('pricing', model.pageSize);
+        }}
         disableRowSelectionOnClick
         rowModesModel={rowModesModel}
         onRowModesModelChange={handleRowModesModelChange}

--- a/web/src/views/Redemption/index.jsx
+++ b/web/src/views/Redemption/index.jsx
@@ -15,7 +15,7 @@ import RedemptionTableRow from './component/TableRow';
 import KeywordTableHead from 'ui-component/TableHead';
 import TableToolBar from 'ui-component/TableToolBar';
 import { API } from 'utils/api';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import { Icon } from '@iconify/react';
 import EditeModal from './component/EditModal';
 import { useTranslation } from 'react-i18next';
@@ -26,7 +26,7 @@ export default function Redemption() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('id');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('redemption'));
   const [listCount, setListCount] = useState(0);
   const [searchKeyword, setSearchKeyword] = useState('');
   const [searching, setSearching] = useState(false);
@@ -49,8 +49,10 @@ export default function Redemption() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('redemption', newRowsPerPage);
   };
 
   const searchRedemptions = async (event) => {

--- a/web/src/views/Task/index.jsx
+++ b/web/src/views/Task/index.jsx
@@ -16,7 +16,7 @@ import KeywordTableHead from 'ui-component/TableHead';
 import TableToolBar from './component/TableToolBar';
 import { API } from 'utils/api';
 import { isAdmin } from 'utils/common';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import { Icon } from '@iconify/react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
@@ -36,7 +36,7 @@ export default function Task() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('id');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('task'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [toolBarValue, setToolBarValue] = useState(originalKeyword);
@@ -59,8 +59,10 @@ export default function Task() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('task', newRowsPerPage);
   };
 
   const searchLogs = async () => {

--- a/web/src/views/Telegram/index.jsx
+++ b/web/src/views/Telegram/index.jsx
@@ -16,7 +16,7 @@ import TelegramTableRow from './component/TableRow';
 import KeywordTableHead from 'ui-component/TableHead';
 import TableToolBar from 'ui-component/TableToolBar';
 import { API } from 'utils/api';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import { Icon } from '@iconify/react';
 import EditeModal from './component/EditModal';
 
@@ -27,7 +27,7 @@ export default function Telegram() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('id');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('telegram'));
   const [listCount, setListCount] = useState(0);
   const [searchKeyword, setSearchKeyword] = useState('');
   const [searching, setSearching] = useState(false);
@@ -52,8 +52,10 @@ export default function Telegram() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('telegram', newRowsPerPage);
   };
 
   const searchMenus = async (event) => {

--- a/web/src/views/Token/index.jsx
+++ b/web/src/views/Token/index.jsx
@@ -19,7 +19,7 @@ import { API } from 'utils/api';
 import { Icon } from '@iconify/react';
 import EditeModal from './component/EditModal';
 import { useSelector } from 'react-redux';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import { useTranslation } from 'react-i18next';
 import { UserContext } from 'contexts/UserContext';
 
@@ -28,7 +28,7 @@ export default function Token() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('id');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('token'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
@@ -54,8 +54,10 @@ export default function Token() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('token', newRowsPerPage);
   };
 
   const searchTokens = async (event) => {

--- a/web/src/views/User/index.jsx
+++ b/web/src/views/User/index.jsx
@@ -16,7 +16,7 @@ import UsersTableRow from './component/TableRow';
 import KeywordTableHead from 'ui-component/TableHead';
 import TableToolBar from 'ui-component/TableToolBar';
 import { API } from 'utils/api';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import EditeModal from './component/EditModal';
 
 import { useTranslation } from 'react-i18next';
@@ -26,7 +26,7 @@ export default function Users() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('id');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('user'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
@@ -49,8 +49,10 @@ export default function Users() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('user', newRowsPerPage);
   };
 
   const searchUsers = async (event) => {

--- a/web/src/views/UserGroup/index.jsx
+++ b/web/src/views/UserGroup/index.jsx
@@ -14,7 +14,7 @@ import { Button, Card, Stack, Container, Typography } from '@mui/material';
 import UserGroupTableRow from './component/TableRow';
 import KeywordTableHead from 'ui-component/TableHead';
 import { API } from 'utils/api';
-import { ITEMS_PER_PAGE, PAGE_SIZE_OPTIONS } from 'constants';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 import EditeModal from './component/EditModal';
 import { Icon } from '@iconify/react';
 
@@ -25,7 +25,7 @@ export default function UserGroup() {
   const [page, setPage] = useState(0);
   const [order, setOrder] = useState('desc');
   const [orderBy, setOrderBy] = useState('id');
-  const [rowsPerPage, setRowsPerPage] = useState(ITEMS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => getPageSize('userGroup'));
   const [listCount, setListCount] = useState(0);
   const [searching, setSearching] = useState(false);
   const [userGroup, setUserGroup] = useState([]);
@@ -47,8 +47,10 @@ export default function UserGroup() {
   };
 
   const handleChangeRowsPerPage = (event) => {
+    const newRowsPerPage = parseInt(event.target.value, 10);
     setPage(0);
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(newRowsPerPage);
+    savePageSize('userGroup', newRowsPerPage);
   };
 
   const fetchData = async (page, rowsPerPage, order, orderBy) => {


### PR DESCRIPTION
- 在 CommonConstants.js 中新增 getPageSize 和 savePageSize 函数，用于管理页面大小的本地存储。
- 更新多个视图组件，使用 getPageSize 函数初始化每页行数，并在行数变化时调用 savePageSize 保存设置。
- 确保用户在不同页面间切换时，能够保持自定义的页面大小设置。

close [#539](https://github.com/MartialBE/one-hub/issues/539)

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/05eacc1a-d0d4-4893-88c0-d76b47ce4772)

