### PR TITLE
feat(auth): 添加 OIDC ID 认证支持，防止用户修改OIDC平台USERNAME而无法进行认证。

### DIFF
--- a/controller/oidc.go
+++ b/controller/oidc.go
@@ -196,6 +196,15 @@ func OIDCAuth(c *gin.Context) {
 		return
 	}
 
+	// 检测邀请码
+	var inviterId int
+	affCode := c.Query("aff")
+	if affCode != "" {
+		inviterId, _ = model.GetUserIdByAffCode(affCode)
+	}
+	if inviterId > 0 {
+		user.InviterId = inviterId
+	}
 	// 填充用户信息并创建账户
 	user.Username = userName.(string)
 	if email, ok := claims["email"]; ok && email != nil {

--- a/controller/oidc.go
+++ b/controller/oidc.go
@@ -51,6 +51,8 @@ func OIDCEndpoint(c *gin.Context) {
 	})
 }
 
+// OIDCAuth 通过OIDC登录
+// 首先通过OIDC ID进行登录、如果登录失败尝试使用USERNAME 进行登录（遵循用户禁用条件），如果OIDC ID和USERNAME都不存在则注册新用户（遵循是否开启注册功能条件）
 func OIDCAuth(c *gin.Context) {
 	if !config.OIDCAuthEnabled {
 		c.JSON(http.StatusOK, gin.H{
@@ -59,6 +61,8 @@ func OIDCAuth(c *gin.Context) {
 		})
 		return
 	}
+
+	// 验证state参数
 	session := sessions.Default(c)
 	state := c.Query("state")
 	if state == "" || session.Get("oauth_state") == nil || state != session.Get("oauth_state").(string) {
@@ -68,6 +72,8 @@ func OIDCAuth(c *gin.Context) {
 		})
 		return
 	}
+
+	// 获取OIDC配置
 	oidcConfig, err := oidc.GetOIDCConfigInstance()
 	if err != nil {
 		logger.SysError("获取 OIDC 配置失败, err: " + err.Error())
@@ -77,15 +83,16 @@ func OIDCAuth(c *gin.Context) {
 		})
 		return
 	}
-	// 从请求中获取授权码
+
+	// 处理授权码并获取token
 	code := c.Query("code")
-	// 使用授权码换取ID Token
 	ctx := context.Background()
 	token, err := oidcConfig.OAuth2Config.Exchange(ctx, code)
 	if err != nil {
 		c.String(http.StatusBadRequest, "Failed to exchange token: %v", err)
 		return
 	}
+
 	// 验证ID Token
 	idToken, err := oidcConfig.Verifier.Verify(ctx, token.Extra("id_token").(string))
 	if err != nil {
@@ -93,73 +100,124 @@ func OIDCAuth(c *gin.Context) {
 		return
 	}
 
-	// 获取用户信息
+	// 检测OIDC用户ID
+	if idToken.Subject == "" {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "ID Token 中没有 Subject",
+		})
+		return
+	}
+
+	// 解析用户信息
 	claims := make(map[string]interface{})
 	if err := idToken.Claims(&claims); err != nil {
 		c.String(http.StatusBadRequest, "Failed to parse claims: %v", err)
 		return
 	}
-	// 从claims中获取用户名称
-	userName := claims[config.OIDCUsernameClaims]
-	if userName == nil {
+
+	// 获取用户名
+	userName, ok := claims[config.OIDCUsernameClaims]
+	if !ok || userName == nil {
 		c.JSON(http.StatusOK, gin.H{
 			"message": "用户没有OIDC登录权限",
 			"success": false,
 		})
 		return
 	}
+
+	// 初始化用户对象
 	user := model.User{
 		Username: userName.(string),
+		OidcId:   idToken.Subject,
 	}
-	err = user.FillUserByUsername()
-	if err != nil {
-		logger.SysError("查询用户错误：" + err.Error())
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// 用户不存在
-			logger.SysError("用户不存在：" + err.Error())
-			if config.RegisterEnabled {
-				user.Username = userName.(string)
-				email := claims["email"]
-				if email != nil {
-					user.Email = email.(string)
-				}
-				display_name := claims["displayName"]
-				if display_name != nil {
-					user.DisplayName = display_name.(string)
-				}
-				user.Role = config.RoleCommonUser
-				user.Status = config.UserStatusEnabled
 
-				if err := user.Insert(0); err != nil {
-					c.JSON(http.StatusOK, gin.H{
-						"success": false,
-						"message": err.Error(),
-					})
-					return
-				}
-			} else {
-				c.JSON(http.StatusOK, gin.H{
-					"success": false,
-					"message": "管理员关闭了新用户注册",
-				})
-				return
-			}
-		} else if err != nil {
-			logger.SysError("其他错误：" + err.Error())
-			c.JSON(http.StatusOK, gin.H{
-				"message": err.Error(),
-				"success": false,
-			})
+	// 尝试通过OIDCid查询用户
+	if err = user.FillUserByOidcId(); err == nil {
+		if user.Status == config.UserStatusEnabled {
+			setupLogin(&user, c)
 			return
 		}
-	}
-
-	if user.Status != config.UserStatusEnabled {
 		c.JSON(http.StatusOK, gin.H{
 			"message": "用户已被封禁或不存在",
 			"success": false,
 		})
 		return
 	}
+
+	// OIDCid查询失败，则尝试通过username查询
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		logger.SysError("查询用户错误: " + err.Error())
+		c.JSON(http.StatusOK, gin.H{
+			"message": err.Error(),
+			"success": false,
+		})
+		return
+	}
+
+	if err = user.FillUserByUsername(); err == nil {
+		if user.Status == config.UserStatusEnabled {
+			// 如果通过用户名查询用户成功、则补全用户OIDC ID并且登录
+			user.OidcId = idToken.Subject
+			ok := user.Update(false)
+			if ok != nil {
+				c.JSON(http.StatusOK, gin.H{
+					"message": ok.Error(),
+					"success": false,
+				})
+				return
+			}
+			setupLogin(&user, c)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"message": "用户已被封禁或不存在",
+			"success": false,
+		})
+		return
+	}
+
+	// 用户不存在，尝试注册
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		logger.SysError("查询用户错误: " + err.Error())
+		c.JSON(http.StatusOK, gin.H{
+			"message": err.Error(),
+			"success": false,
+		})
+		return
+	}
+
+	// 注册新用户
+	if !config.RegisterEnabled {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "管理员关闭了新用户注册",
+		})
+		return
+	}
+
+	// 填充用户信息并创建账户
+	user.Username = userName.(string)
+	if email, ok := claims["email"]; ok && email != nil {
+		user.Email = email.(string)
+	}
+	if displayName, ok := claims["displayName"]; ok && displayName != nil {
+		user.DisplayName = displayName.(string)
+	}
+	if avatarUrl, ok := claims["avatar"]; ok && avatarUrl != nil {
+		user.AvatarUrl = avatarUrl.(string)
+	}
+	user.OidcId = idToken.Subject
+	user.Role = config.RoleCommonUser
+	user.Status = config.UserStatusEnabled
+
+	if err := user.Insert(0); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+
 	setupLogin(&user, c)
 }

--- a/model/user.go
+++ b/model/user.go
@@ -24,6 +24,7 @@ type User struct {
 	Status           int            `json:"status" gorm:"type:int;default:1"` // enabled, disabled
 	Email            string         `json:"email" gorm:"index" validate:"max=50"`
 	AvatarUrl        string         `json:"avatar_url" gorm:"type:varchar(500);column:avatar_url;default:''"`
+	OidcId           string         `json:"oidc_id" gorm:"column:oidc_id;index"`
 	GitHubId         string         `json:"github_id" gorm:"column:github_id;index"`
 	GitHubIdNew      int            `json:"github_id_new" gorm:"column:github_id_new;index"`
 	WeChatId         string         `json:"wechat_id" gorm:"column:wechat_id;index"`
@@ -69,7 +70,7 @@ func GetUsersList(params *GenericParams) (*DataResult[User], error) {
 		if common.UsingPostgreSQL {
 			groupCol = `"group"`
 		}
-		db = db.Where("id = ? or username LIKE ? or email LIKE ? or display_name LIKE ? or " + groupCol + " LIKE ?", utils.String2Int(params.Keyword), params.Keyword+"%", params.Keyword+"%", params.Keyword+"%", params.Keyword+"%")
+		db = db.Where("id = ? or username LIKE ? or email LIKE ? or display_name LIKE ? or "+groupCol+" LIKE ?", utils.String2Int(params.Keyword), params.Keyword+"%", params.Keyword+"%", params.Keyword+"%", params.Keyword+"%")
 	}
 
 	return PaginateAndOrder[User](db, &params.PaginationParams, &users, allowedUserOrderFields)
@@ -283,6 +284,17 @@ func (user *User) FillUserByLarkId() error {
 		return errors.New("lark id 为空！")
 	}
 	DB.Where(User{LarkId: user.LarkId}).First(user)
+	return nil
+}
+
+func (user *User) FillUserByOidcId() error {
+	if user.OidcId == "" {
+		return errors.New("OIDC ID 为空！")
+	}
+	err := DB.Where(User{OidcId: user.OidcId}).First(user)
+	if err != nil {
+		return err.Error
+	}
 	return nil
 }
 

--- a/web/src/views/Profile/index.jsx
+++ b/web/src/views/Profile/index.jsx
@@ -17,7 +17,7 @@ import {
 } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import SubCard from 'ui-component/cards/SubCard';
-import { IconBrandWechat, IconBrandGithub, IconMail, IconBrandTelegram } from '@tabler/icons-react';
+import { IconBrandWechat, IconBrandGithub, IconMail, IconBrandTelegram, IconBrandOauth } from '@tabler/icons-react';
 import Label from 'ui-component/Label';
 import { API } from 'utils/api';
 import { showError, showSuccess, onGitHubOAuthClicked, copy, trims, onLarkOAuthClicked } from 'utils/common';
@@ -27,6 +27,7 @@ import { useSelector } from 'react-redux';
 import EmailModal from './component/EmailModal';
 import Turnstile from 'react-turnstile';
 import LarkIcon from 'assets/images/icons/lark.svg';
+import OidcIcon from 'assets/images/icons/oidc.svg';
 import { useTheme } from '@mui/material/styles';
 
 const validationSchema = Yup.object().shape({
@@ -167,6 +168,11 @@ export default function Profile() {
               {status.lark_login && (
                 <Label variant="ghost" color={inputs.lark_id ? 'primary' : 'default'}>
                   <SvgIcon component={LarkIcon} inheritViewBox="0 0 24 24" /> {inputs.lark_id || t('profilePage.notBound')}
+                </Label>
+              )}
+              {status.oidc_auth && (
+                <Label variant="ghost" color={inputs.oidc_id ? 'primary' : 'default'}>
+                  <IconBrandOauth /> {inputs.oidc_id || t('profilePage.notBound')}
                 </Label>
               )}
             </Stack>


### PR DESCRIPTION
- 新增 OIDC 认证流程，包括授权码验证、ID Token 解析和用户信息获取
- 实现通过 OIDC ID 和用户名查询用户的功能- 添加新用户注册逻辑，支持通过 OIDC 创建新账户
- 在用户模型中增加 OIDC ID 字段并添加相关查询方法- 更新用户界面，在个人资料页面添加 OIDC 账号绑定显示


我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/711a1402-a432-4519-8435-bb21c311e260)
