### PR TITLE
标签渠道列表里的分页行数支持记忆能力

### DIFF
--- a/web/src/views/Channel/component/TableRow.jsx
+++ b/web/src/views/Channel/component/TableRow.jsx
@@ -54,6 +54,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { copy, renderQuota } from 'utils/common';
 import { ChannelCheck } from './ChannelCheck';
+import { PAGE_SIZE_OPTIONS, getPageSize, savePageSize } from 'constants';
 
 const StyledMenu = styled((props) => (
   <Menu
@@ -127,7 +128,7 @@ export default function ChannelTableRow({ item, manageChannel, onRefresh, groupO
   const [selectedChannels, setSelectedChannels] = useState([]);
   const [currentTestingChannel, setCurrentTestingChannel] = useState(null);
   const [tagPage, setTagPage] = useState(0);
-  const [tagRowsPerPage, setTagRowsPerPage] = useState(10);
+  const [tagRowsPerPage, setTagRowsPerPage] = useState(() => getPageSize('channelTag'));
   const tagModelPopover = usePopover();
 
   const batchConfirm = useBoolean();
@@ -168,8 +169,10 @@ export default function ChannelTableRow({ item, manageChannel, onRefresh, groupO
   };
 
   const handleChangeTagRowsPerPage = (event) => {
-    setTagRowsPerPage(parseInt(event.target.value, 10));
+    const newRowsPerPage = parseInt(event.target.value, 10);
+    setTagRowsPerPage(newRowsPerPage);
     setTagPage(0);
+    savePageSize('channelTag', newRowsPerPage);
   };
 
   const handleToggleChannel = (channelId) => {
@@ -1123,7 +1126,7 @@ export default function ChannelTableRow({ item, manageChannel, onRefresh, groupO
                             onPageChange={handleChangeTagPage}
                             rowsPerPage={tagRowsPerPage}
                             onRowsPerPageChange={handleChangeTagRowsPerPage}
-                            rowsPerPageOptions={[10, 25, 50, 100]}
+                            rowsPerPageOptions={PAGE_SIZE_OPTIONS}
                             labelRowsPerPage="每页行数:"
                             labelDisplayedRows={({ from, to, count }) => `${from}-${to} 共 ${count}`}
                             sx={{


### PR DESCRIPTION
如题，补上之前PR遗漏的标签渠道列表里的分页逻辑修改

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/e6155a8c-b428-44d1-816f-1cc98670228b)
