### PR TITLE
fix(Dashboard): 修复快速开始卡片的聊天链接显示逻辑

### DIFF
--- a/web/src/views/Dashboard/component/QuickStartCard.jsx
+++ b/web/src/views/Dashboard/component/QuickStartCard.jsx
@@ -17,7 +17,7 @@ const QuickStartCard = () => {
   const [localOptions, setLocalOptions] = useState([]);
   const theme = useTheme();
   const siteInfo = useSelector((state) => state.siteInfo);
-  const chatLinks = JSON.parse(siteInfo.chat_links);
+  const chatLinks = siteInfo.chat_links ? JSON.parse(siteInfo.chat_links) : [];
   const baseServer = siteInfo.server_address;
 
   const loadTokens = useCallback(async () => {
@@ -35,7 +35,7 @@ const QuickStartCard = () => {
   useEffect(() => {
     loadTokens().then(() => {
       if (key !== '') {
-        if (chatLinks) {
+        if (chatLinks.length > 0) {
           let server = '';
           if (baseServer) {
             server = baseServer;
@@ -66,8 +66,10 @@ const QuickStartCard = () => {
           });
           setQuickStartOptions(newQuickStartOptions);
           setLocalOptions(newLocalOptions);
+          setIsShow(true);
+        } else {
+          setIsShow(false);
         }
-        setIsShow(true);
       } else {
         setIsShow(false);
       }

--- a/web/src/views/Dashboard/component/QuickStartCard.jsx
+++ b/web/src/views/Dashboard/component/QuickStartCard.jsx
@@ -17,7 +17,7 @@ const QuickStartCard = () => {
   const [localOptions, setLocalOptions] = useState([]);
   const theme = useTheme();
   const siteInfo = useSelector((state) => state.siteInfo);
-  const chatLinks = siteInfo.chat_links ? JSON.parse(siteInfo.chat_links) : [];
+  const chatLinks = siteInfo.chat_links && siteInfo.chat_links != '' ? JSON.parse(siteInfo.chat_links) : [];
   const baseServer = siteInfo.server_address;
 
   const loadTokens = useCallback(async () => {


### PR DESCRIPTION
- 修复了 chatLinks 可能为 null 导致的解析错误
- 优化了聊天链接的判断条件，确保仅在存在链接时显示
