### PR TITLE
refactor(Dashboard): 优化 QuickStartCard 组件中的聊天链接处理逻辑只有点击按钮才生成默认key

### DIFF
--- a/web/src/views/Dashboard/component/QuickStartCard.jsx
+++ b/web/src/views/Dashboard/component/QuickStartCard.jsx
@@ -17,40 +17,14 @@ const QuickStartCard = () => {
   const chatLinks = siteInfo.chat_links && siteInfo.chat_links != '' ? JSON.parse(siteInfo.chat_links) : [];
   const baseServer = siteInfo.server_address;
 
-  const initChatOptions = useCallback(
-    (key) => {
-      if (chatLinks.length > 0) {
-        let server = '';
-        if (baseServer) {
-          server = baseServer;
-        } else {
-          server = window.location.host;
-        }
-        server = encodeURIComponent(server);
-        const useKey = 'sk-' + key;
-
-        const newQuickStartOptions = [];
-        const newLocalOptions = [];
-
-        chatLinks.forEach((item) => {
-          var url = replaceChatPlaceholders(item.url, useKey, server);
-          if (item.url.startsWith('http')) {
-            newQuickStartOptions.push({
-              icon: <IconMessageChatbot />,
-              title: item.name,
-              url: url
-            });
-          } else {
-            newLocalOptions.push({
-              icon: <IconAppWindow />,
-              title: item.name,
-              url: url
-            });
-          }
-        });
-      }
+  const getProcessedUrl = useCallback(
+    (url, key) => {
+      let server = baseServer || window.location.host;
+      server = encodeURIComponent(server);
+      const useKey = 'sk-' + key;
+      return replaceChatPlaceholders(url, useKey, server);
     },
-    [chatLinks, baseServer]
+    [baseServer]
   );
 
   const handleClick = async (url) => {
@@ -60,8 +34,7 @@ const QuickStartCard = () => {
         const { success, message, data } = res.data;
         if (success) {
           setKey(data);
-          initChatOptions(data);
-          window.open(replaceChatPlaceholders(url, 'sk-' + data, encodeURIComponent(baseServer || window.location.host)), '_blank');
+          window.open(getProcessedUrl(url, data), '_blank');
         } else {
           console.log('message', message);
         }
@@ -69,7 +42,7 @@ const QuickStartCard = () => {
         console.error('Failed to get token:', error);
       }
     } else {
-      window.open(url, '_blank');
+      window.open(getProcessedUrl(url, key), '_blank');
     }
   };
 


### PR DESCRIPTION
- 移除了不必要的 initChatOptions 函数，简化了代码结构
- 新增 getProcessedUrl 函数，用于生成处理后的聊天链接
- 优化了 handleClick 方法，使用新的 getProcessedUrl 函数处理聊天链接
- 删除了未使用的 newQuickStartOptions 和 newLocalOptions 数组