### PR TITLE
fix(model): 修复禁用频道关键词配置项名称重复问题

### DIFF
--- a/model/option.go
+++ b/model/option.go
@@ -119,7 +119,7 @@ func InitOptionMap() {
 	config.GlobalOption.RegisterBool("GeminiAPIEnabled", &config.GeminiAPIEnabled)
 	config.GlobalOption.RegisterBool("ClaudeAPIEnabled", &config.ClaudeAPIEnabled)
 
-	config.GlobalOption.RegisterCustom("DisableChannelKeywordsDisableChannelKeywords", func() string {
+	config.GlobalOption.RegisterCustom("DisableChannelKeywords", func() string {
 		return common.DisableChannelKeywordsInstance.GetKeywords()
 	}, func(value string) error {
 		common.DisableChannelKeywordsInstance.Load(value)


### PR DESCRIPTION
- 将配置项名称从 "DisableChannelKeywordsDisableChannelKeywords" 修改为 "DisableChannelKeywords"