### PR TITLE
fix(common): 修复 API 限流窗口时间设置错误

### DIFF
--- a/common/limit/api_limiter.go
+++ b/common/limit/api_limiter.go
@@ -22,7 +22,7 @@ func NewAPILimiter(rpm int) RateLimiter {
 	return NewCountLimiter(
 		int(ratePerSecond),
 		rpm,
-		window,
+		1*time.Second,
 	)
 }
 


### PR DESCRIPTION
- 将 API 限流窗口时间从变量 window 修改为 1 秒
- 确保限流器以每秒为单位进行计数

