### PR TITLE
feat(limit): 实现 token bucket限流器的实时 RPM 统计

### DIFF
--- a/common/limit/api_limiter.go
+++ b/common/limit/api_limiter.go
@@ -22,19 +22,27 @@ func NewAPILimiter(rpm int) RateLimiter {
 		// 如果是rpm设定值较小，说明并发较小，使用固定窗口
 		return NewCountLimiter(rpm, rpm, window)
 	}
+	// 将RPM转换为每秒速率
+	ratePerSecond := float64(rpm) / 60
+	burst := int(ratePerSecond * TokenBurstMultiplier)
+	return NewTokenLimiter(
+		int(ratePerSecond),
+		rpm,
+		burst,
+	)
 	// 如果是rpm设定值较大，说明并发较大，限流敏感，使用滑动窗口灵活限流
-	return NewSlidingWindowLimiter(rpm, rpm, window)
+	//return NewSlidingWindowLimiter(rpm, rpm, window)
 }
 
 // GetMaxRate 获取限流器的最大速率（rpm）
 func GetMaxRate(limiter RateLimiter) int {
 	switch l := limiter.(type) {
 	case *CountLimiter:
-		return l.actualRate
+		return l.rpm
 	case *TokenLimiter:
-		return l.actualRate
+		return l.rpm
 	case *SlidingWindowLimiter:
-		return l.actualRate
+		return l.rpm
 	default:
 		return 0
 	}

--- a/common/limit/countlimit.go
+++ b/common/limit/countlimit.go
@@ -23,16 +23,16 @@ var (
 )
 
 type CountLimiter struct {
-	rate       int
-	actualRate int
-	window     time.Duration
+	rate   int
+	rpm    int
+	window time.Duration
 }
 
-func NewCountLimiter(rate int, actualRate int, window time.Duration) *CountLimiter {
+func NewCountLimiter(rate int, rpm int, window time.Duration) *CountLimiter {
 	return &CountLimiter{
-		rate:       rate,
-		actualRate: actualRate,
-		window:     window,
+		rate:   rate,
+		rpm:    rpm,
+		window: window,
 	}
 }
 

--- a/common/limit/slidingwindow.go
+++ b/common/limit/slidingwindow.go
@@ -24,17 +24,17 @@ var (
 
 // SlidingWindowLimiter 滑动窗口限流器
 type SlidingWindowLimiter struct {
-	rate       int           // 最大请求速率
-	actualRate int           // 实际请求速率
-	window     time.Duration // 窗口大小
+	rate   int           // 最大请求速率
+	rpm    int           // 系统设置的RPM阈值
+	window time.Duration // 窗口大小
 }
 
 // NewSlidingWindowLimiter 创建新的滑动窗口限流器
-func NewSlidingWindowLimiter(rate int, actualRate int, window time.Duration) *SlidingWindowLimiter {
+func NewSlidingWindowLimiter(rate int, rpm int, window time.Duration) *SlidingWindowLimiter {
 	return &SlidingWindowLimiter{
-		rate:       rate,
-		actualRate: actualRate,
-		window:     window,
+		rate:   rate,
+		rpm:    rpm,
+		window: window,
 	}
 }
 

--- a/common/limit/tokengetscript.lua
+++ b/common/limit/tokengetscript.lua
@@ -1,31 +1,64 @@
 -- KEYS[1] as tokens_key
 -- KEYS[2] as timestamp_key
--- ARGV[1] as rate
--- ARGV[2] as capacity
--- ARGV[3] as now
+-- KEYS[3] as request_counter_key (for counting requests)
+-- KEYS[4] as last_minute_key (for recording the timestamp of the last minute)
+-- ARGV[1] as rate (per second rate)
+-- ARGV[2] as capacity (bucket capacity)
+-- ARGV[3] as now (current timestamp)
+-- ARGV[4] as actualRate (actual RPM setting)
+
 local rate = tonumber(ARGV[1])
 local capacity = tonumber(ARGV[2])
 local now = tonumber(ARGV[3])
+local actualRate = tonumber(ARGV[4]) -- actual RPM value
 local fill_time = capacity/rate
 local ttl = math.floor(fill_time*2)
 
--- 获取当前令牌数量，如果键不存在则返回最大容量（未使用）
+-- Get the current token count, if the key does not exist, return the maximum capacity (unused)
 local last_tokens = redis.call("get", KEYS[1])
 if last_tokens == false then
-    return capacity
+    return {capacity, 0, actualRate} -- Return array: [remaining tokens, current RPM, max allowed RPM]
 end
 last_tokens = tonumber(last_tokens)
 
--- 获取上次刷新时间
+-- Get the last refresh time
 local last_refreshed = redis.call("get", KEYS[2])
 if last_refreshed == false then
-    return capacity
+    return {capacity, 0, actualRate} -- Return array: [remaining tokens, current RPM, max allowed RPM]
 end
 last_refreshed = tonumber(last_refreshed)
 
--- 计算时间差并补充令牌
+-- Calculate the time difference and refill tokens
 local delta = math.max(0, now-last_refreshed)
 local filled_tokens = math.min(capacity, last_tokens+(delta*rate))
 
--- 返回当前可用的令牌数
-return filled_tokens 
+-- Get the current counter value
+local request_count = redis.call("get", KEYS[3])
+if request_count == false then
+    request_count = 0
+else
+    request_count = tonumber(request_count)
+end
+
+-- Get the timestamp of the last minute
+local last_minute = redis.call("get", KEYS[4])
+if last_minute == false then
+    last_minute = now - (now % 60) -- Start time of the current minute
+    redis.call("setex", KEYS[4], 120, last_minute) -- Set to expire in 2 minutes
+else
+    last_minute = tonumber(last_minute)
+end
+
+-- Check if entering a new minute
+local current_minute = now - (now % 60)
+local rpm = request_count
+
+if current_minute > last_minute then
+    -- Entering a new minute, reset the counter and update the timestamp
+    rpm = 0 -- New minute starts, current RPM is 0
+    redis.call("setex", KEYS[3], 120, 0) -- Reset counter, set to expire in 2 minutes
+    redis.call("setex", KEYS[4], 120, current_minute) -- Update timestamp
+end
+
+-- Return array: [remaining tokens, current RPM, max allowed RPM]
+return {filled_tokens, rpm, actualRate} 

--- a/common/limit/tokenscript.lua
+++ b/common/limit/tokenscript.lua
@@ -1,10 +1,19 @@
--- to be compatible with aliyun redis, we cannot use `local key = KEYS[1]` to reuse the key
+-- Modify counter logic to ensure it matches the set RPM value
 -- KEYS[1] as tokens_key
 -- KEYS[2] as timestamp_key
+-- KEYS[3] as request_counter_key (for counting requests)
+-- KEYS[4] as last_minute_key (for recording the timestamp of the last minute)
+-- ARGV[1] as rate (per second rate)
+-- ARGV[2] as capacity (bucket capacity)
+-- ARGV[3] as now (current timestamp)
+-- ARGV[4] as requested (number of tokens requested)
+-- ARGV[5] as rpm (actual RPM threshold)
+
 local rate = tonumber(ARGV[1])
 local capacity = tonumber(ARGV[2])
 local now = tonumber(ARGV[3])
 local requested = tonumber(ARGV[4])
+local actualRate = tonumber(ARGV[5]) -- actual RPM value
 local fill_time = capacity/rate
 local ttl = math.floor(fill_time*2)
 local last_tokens = tonumber(redis.call("get", KEYS[1]))
@@ -23,6 +32,39 @@ local allowed = filled_tokens >= requested
 local new_tokens = filled_tokens
 if allowed then
     new_tokens = filled_tokens - requested
+    
+    -- If the request is allowed, increment the request counter
+    -- Get the current counter value
+    local request_count = redis.call("get", KEYS[3])
+    if request_count == false then
+        request_count = 0
+    else
+        request_count = tonumber(request_count)
+    end
+    
+    -- Get the timestamp of the last minute
+    local last_minute = redis.call("get", KEYS[4])
+    local current_minute = now - (now % 60)
+    
+    if last_minute == false then
+        -- If there is no record of the last minute, initialize
+        last_minute = current_minute
+        redis.call("setex", KEYS[4], 120, current_minute) -- set to expire in 2 minutes
+        request_count = 1 -- new minute starts, count from 1
+    else
+        last_minute = tonumber(last_minute)
+        if current_minute > last_minute then
+            -- Enter a new minute, reset the counter and update the timestamp
+            request_count = 1 -- new minute starts, count from 1
+            redis.call("setex", KEYS[4], 120, current_minute) -- update timestamp
+        else
+            -- In the same minute, counter plus 1, but not more than actualRate
+            request_count = request_count + 1
+        end
+    end
+    
+    -- Update counter
+    redis.call("setex", KEYS[3], 120, request_count) -- set to expire in 2 minutes
 end
 
 redis.call("setex", KEYS[1], ttl, new_tokens)


### PR DESCRIPTION
- 新增计数器逻辑，记录每个请求的 RPM- 在 tokengetscript.lua 和 tokenscript.lua 中添加 RPM 相关的处理
- 修改 TokenLimiter 结构，增加 rpm 字段- 更新 GetCurrentRate 方法，返回实时 RPM
- 调整 reserveN 方法，处理 RPM 限制这个改动实现了在 token bucket 限流器中记录和返回实时 RPM 的功能，以便更准确地监控和控制 API 调用速率。
【模拟并发测试100~500毫秒请求间隔还是令牌桶的方案比较合适，滑动窗口方案在突发情况或者窗口多的情况不理想】
我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/bca5b74d-19ef-4841-95e0-3d56cec33d9e)
![image](https://github.com/user-attachments/assets/2f224b5f-880d-4141-9b6a-e5f78d673741)
![image](https://github.com/user-attachments/assets/5706e5fa-276d-4f88-a271-24763765ae18)
