### PR TITLE
fix(GitHub): 修复github登录失败问题

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -17,6 +17,7 @@ func InitConf() {
 	RequestInterval = time.Duration(viper.GetInt("polling_interval")) * time.Second
 	SessionSecret = utils.GetOrDefault("session_secret", SessionSecret)
 	UserInvoiceMonth = viper.GetBool("user_invoice_month")
+	GitHubProxy = viper.GetString("github_proxy")
 }
 
 func setEnv() {

--- a/common/config/constants.go
+++ b/common/config/constants.go
@@ -154,6 +154,7 @@ var ExtraTokenPriceJson = ""
 
 var ChatImageRequestProxy = ""
 
+var GitHubProxy = ""
 var GitHubClientId = ""
 var GitHubClientSecret = ""
 var GitHubOldIdCloseEnabled = false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,7 +33,8 @@ auto_price_updates: false # 启用自动更新价格，可选值为 true 和 fal
 auto_price_updates_mode: "system" # 可选值为 "add":仅增加 和 "overwrite"：全部覆盖，会删除系统现有的价格配置，"update":只更新系统现有的价格，"system":使用程序内置，使用程序内置仅仅项目启动的时候使用内置更新并且自动从价格服务器更新失效，默认为 "system"。（以上模式不含被lock的数据）
 auto_price_updates_interval: 1440 # 自动更新价格的时间间隔，单位为分钟，默认为 1440。
 update_price_service: "https://raw.githubusercontent.com/MartialBE/one-api/prices/prices.json" # 设置之后将使用指定的价格服务更新价格
-user_invoice_month:false #是否开启用户月账单功能
+user_invoice_month: false #是否开启用户月账单功能
+github_proxy: "" #github登录请求代理例如socks://127.0.0.1:10808
 
 # 令牌设置
 user_token_secret: "" # 用户令牌密钥, 请设置至少32位的随机字符串，修改后用户令牌将无法验证，例如：vWVmFxp5YIOXuHhEod8jBcqiw0zKP2fk
@@ -112,3 +113,5 @@ search:
     url: "" # searxng 地址 关键词请用{query}， 例如 "http://127.0.0.1:8080/search?category_general=1&safesearch=2&q={query}&format=json&engines=bing,google"
   tavily:
     key: "" # tavily 密钥
+
+

--- a/model/option.go
+++ b/model/option.go
@@ -63,6 +63,7 @@ func InitOptionMap() {
 	config.GlobalOption.RegisterString("Logo", &config.Logo)
 	config.GlobalOption.RegisterString("ServerAddress", &config.ServerAddress)
 	config.GlobalOption.RegisterString("GitHubClientId", &config.GitHubClientId)
+	config.GlobalOption.RegisterString("GitHubClientSecret", &config.GitHubClientSecret)
 
 	config.GlobalOption.RegisterString("OIDCClientId", &config.OIDCClientId)
 	config.GlobalOption.RegisterString("OIDCClientSecret", &config.OIDCClientSecret)


### PR DESCRIPTION
- 新增配置项github_proxy，使GitHub登录请求支持通过HTTP/HTTPS/SOCKS5代理发送，提升灵活性和适配性。
- 修复github登录失败问题


