### PR TITLE
fix(controller): 修复发票时间验证逻辑问题

### DIFF
--- a/controller/invoice.go
+++ b/controller/invoice.go
@@ -16,13 +16,14 @@ func GenInvoice(c *gin.Context) {
 		common.APIRespondWithError(c, http.StatusOK, fmt.Errorf("invalid time format"))
 		return
 	}
-	// 如果invoiceTime大于当前月份返回错误
-	if invoiceTime.After(time.Now().AddDate(0, 1, -time.Now().Day())) {
-		common.APIRespondWithError(c, http.StatusOK, fmt.Errorf("invoice time cannot be later than current month"))
+	date := time.Date(invoiceTime.Year(), invoiceTime.Month(), 1, 0, 0, 0, 0, time.Local)
+	// 如果invoiceTime大于等于当前月份返回错误
+	if !invoiceTime.Before(time.Now().Local().AddDate(0, 1, -date.Day())) {
+		common.APIRespondWithError(c, http.StatusOK, fmt.Errorf("invoice time cannot be later than or equal to current month"))
 		return
 	}
 
-	err = model.InsertStatisticsMonthForDate(invoiceTime)
+	err = model.InsertStatisticsMonthForDate(date)
 	if err != nil {
 		common.APIRespondWithError(c, http.StatusOK, err)
 		return


### PR DESCRIPTION
- 修复发票时间验证错误，更新逻辑为不允许发票时间大于等于当前月份。
- 调整 `InsertStatisticsMonthForDate` 调用参数，提升时间计算的可靠性和一致性。

