### PR TITLE
fix channel.go

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -31,7 +31,7 @@ type Channel struct {
 	Group              string  `json:"group" form:"group" gorm:"type:varchar(32);default:'default'"`
 	Tag                string  `json:"tag" form:"tag" gorm:"type:varchar(32);default:''"`
 	UsedQuota          int64   `json:"used_quota" gorm:"bigint;default:0"`
-	ModelMapping       *string `json:"model_mapping" gorm:"type:varchar(1024);default:''"`
+  ModelMapping       *string `json:"model_mapping" gorm:"type:text;default:''"`
 	ModelHeaders       *string `json:"model_headers" gorm:"type:varchar(1024);default:''"`
 	CustomParameter    *string `json:"custom_parameter" gorm:"type:varchar(1024);default:''"`
 	Priority           *int64  `json:"priority" gorm:"bigint;default:0"`


### PR DESCRIPTION
  /home/runner/work/one-hub/one-hub/model/main.go:123 Error 1406 (22001): Data too long for column 'model_mapping' at row 32
[8.613ms] [rows:0] ALTER TABLE `channels` MODIFY COLUMN `model_mapping` varchar(1024) DEFAULT ''

[//]: # "请按照以下格式关联 issue"
[//]: # "请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢"
[//]: # "项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解"
[//]: # "请在提交 PR 之前删除上面的注释"

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
