### PR TITLE
feat(types): 增加思考预算和搜索开关支持

### DIFF
--- a/types/chat.go
+++ b/types/chat.go
@@ -220,8 +220,12 @@ type ChatCompletionRequest struct {
 	Prediction          any                           `json:"prediction,omitempty"`
 	WebSearchOptions    *WebSearchOptions             `json:"web_search_options,omitempty"`
 
-	Reasoning      *ChatReasoning `json:"reasoning,omitempty"`
-	EnableThinking *bool          `json:"enable_thinking,omitempty"` // qwen3 thinking switch
+	Reasoning *ChatReasoning `json:"reasoning,omitempty"`
+
+	// 考虑到后续一些模型逐步采用openai api格式扩展参数的方式进行服务提供，所以考虑把一些模型的特有参数放入可选参数
+	EnableThinking *bool `json:"enable_thinking,omitempty"` // qwen3 思考开关
+	ThinkingBudget *int  `json:"thinking_budget,omitempty"` // qwen3 思考长度，只有enable_thinking开启才生效
+	EnableSearch   *bool `json:"enable_search,omitempty"`   // qwen 搜索开关
 
 	OneOtherArg string `json:"-"`
 }


### PR DESCRIPTION
考虑支持更多模型使用OpenAI API格式扩展参数，新增以下可选参数：
- thinking_budget: qwen3的思考长度，需启用enable_thinking
- enable_search: qwen的搜索开关

