### PR TITLE
fix: input/output format - 修复编辑模型价格input/output字段类型字符串的问题

### DIFF
--- a/web/src/views/Pricing/component/EditModal.jsx
+++ b/web/src/views/Pricing/component/EditModal.jsx
@@ -279,12 +279,19 @@ const EditModal = ({
     if (!singleMode) return; // 单一模式专用
 
     const { name, value, checked } = event.target;
+
+    let finalValue;
+    if (name === 'input' || name === 'output') {
+      finalValue = value === '' ? 0 : Number(value);
+    } else {
+      finalValue = name === 'locked' ? checked : value;
+    }
+
     setInputs((prev) => ({
       ...prev,
-      [name]: name === 'locked' ? checked : value
+      [name]: finalValue
     }));
 
-    // 清除对应字段的错误
     if (errors[name]) {
       setErrors((prev) => ({ ...prev, [name]: null }));
     }


### PR DESCRIPTION
[//]: # "请按照以下格式关联 issue"
[//]: # "请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢"
[//]: # "项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解"
[//]: # "请在提交 PR 之前删除上面的注释"

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：

> 新增模型价格后再次编辑价格时string未转换number。

before:

<img width="1055" alt="image" src="https://github.com/user-attachments/assets/48bf4691-5851-4b18-9d2d-6ae12d4e2d49" />


after:

<img width="1222" alt="image" src="https://github.com/user-attachments/assets/5748e361-32d1-4c21-a48d-85e740215c22" />


