### PR TITLE
feat(dashboard): 增加uptime kuma状态监控面板

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -19,6 +19,9 @@ func InitConf() {
 	UserInvoiceMonth = viper.GetBool("user_invoice_month")
 	GitHubProxy = viper.GetString("github_proxy")
 	MCP_ENABLE = viper.GetBool("mcp.enable") != false
+	UPTIMEKUMA_ENABLE = viper.GetBool("uptime_kuma.enable") != false
+	UPTIMEKUMA_DOMAIN = viper.GetString("uptime_kuma.domain")
+	UPTIMEKUMA_STATUS_PAGE_NAME = viper.GetString("uptime_kuma.status_page_name")
 }
 
 func setEnv() {
@@ -44,4 +47,8 @@ func defaultConfig() {
 	viper.SetDefault("language", "zh_CN")
 	viper.SetDefault("favicon", "")
 	viper.SetDefault("user_invoice_month", false)
+	viper.SetDefault("mcp.enable", false)
+	viper.SetDefault("uptime_kuma.enable", false)
+	viper.SetDefault("uptime_kuma.domain", "")
+	viper.SetDefault("uptime_kuma.status_page_name", "")
 }

--- a/common/config/constants.go
+++ b/common/config/constants.go
@@ -203,6 +203,10 @@ var BatchUpdateInterval = 5
 
 var MCP_ENABLE = false
 
+var UPTIMEKUMA_ENABLE = false
+var UPTIMEKUMA_DOMAIN = ""
+var UPTIMEKUMA_STATUS_PAGE_NAME = ""
+
 // Gemini
 var GeminiAPIEnabled = true
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -117,4 +117,8 @@ search:
 mcp:
   enable: false # 开启mcp服务
 
+uptime_kuma:
+  enable: false # 是否开启uptime kuma状态展示
+  domain: ""     # uptime-kuma项目地址 例如https://status.xxxxx.com
+  status_page_name: "" #  uptime-kuma状态页面slug
 

--- a/controller/misc.go
+++ b/controller/misc.go
@@ -54,6 +54,9 @@ func GetStatus(c *gin.Context) {
 			"SafeToolName":        config.SafeToolName,
 			"SafeKeyWords":        config.SafeKeyWords,
 			"UserInvoiceMonth":    config.UserInvoiceMonth,
+			"UptimeDomain":        config.UPTIMEKUMA_DOMAIN,
+			"UptimePageName":      config.UPTIMEKUMA_STATUS_PAGE_NAME,
+			"UptimeEnabled":       config.UPTIMEKUMA_ENABLE,
 		},
 	})
 }

--- a/controller/uptime_kuma.go
+++ b/controller/uptime_kuma.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"github.com/gin-gonic/gin"
+	"io"
+	"net/http"
+	"one-api/common/config"
+	"strconv"
+	"time"
+)
+
+func UptimeKumaStatusPage(c *gin.Context) {
+	var api = config.UPTIMEKUMA_DOMAIN + "/api/status-page/" + config.UPTIMEKUMA_STATUS_PAGE_NAME + "?t=" + strconv.FormatInt(time.Now().Unix(), 10)
+	resp, err := http.Get(api)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.Data(http.StatusOK, resp.Header.Get("Content-Type"), body)
+}
+func UptimeKumaStatusPageHeartbeat(c *gin.Context) {
+	var api = config.UPTIMEKUMA_DOMAIN + "/api/status-page/heartbeat/" + config.UPTIMEKUMA_STATUS_PAGE_NAME + "?t=" + strconv.FormatInt(time.Now().Unix(), 10)
+	resp, err := http.Get(api)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.Data(http.StatusOK, resp.Header.Get("Content-Type"), body)
+}

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -53,6 +53,8 @@ func SetApiRouter(router *gin.Engine) {
 			{
 				selfRoute.GET("/dashboard", controller.GetUserDashboard)
 				selfRoute.GET("/dashboard/rate", controller.GetRateRealtime)
+				selfRoute.GET("/dashboard/uptimekuma/status-page", controller.UptimeKumaStatusPage)
+				selfRoute.GET("/dashboard/uptimekuma/status-page/heartbeat", controller.UptimeKumaStatusPageHeartbeat)
 				selfRoute.GET("/invoice", controller.GetUserInvoice)
 				selfRoute.GET("/invoice/detail", controller.GetUserInvoiceDetail)
 				selfRoute.GET("/self", controller.GetSelf)

--- a/web/src/config.js
+++ b/web/src/config.js
@@ -6,6 +6,9 @@ const config = {
   fontFamily: `'Roboto', Helvetica, sans-serif`,
   borderRadius: 12,
   siteInfo: {
+    UptimeEnabled: false,
+    UptimeDomain: '',
+    UptimePageName: '',
     UserInvoiceMonth: false,
     chat_link: '',
     display_in_currency: true,

--- a/web/src/i18n/locales/zh_CN.json
+++ b/web/src/i18n/locales/zh_CN.json
@@ -25,6 +25,7 @@
   "menu": {
     "home": "首页",
     "about": "关于",
+    "status": "状态",
     "login": "登录",
     "signup": "注册",
     "signout": "注销",
@@ -56,10 +57,13 @@
     "alreadyHaveAccount": "已经有帐号了?点击登录"
   },
   "dashboard_index": {
+    "title": "仪表盘",
     "model_price": "当前可用模型",
     "today_requests": "今日请求",
     "today_consumption": "今日消费",
     "today_tokens": "今日Token",
+    "tab_dashboard": "概览",
+    "tab_status": "状态",
     "no_data": "无数据",
     "statistics": "统计",
     "no_data_available": "暂无数据",
@@ -85,7 +89,10 @@
     "ComparedWithYesterday": "相比昨日",
     "usage": "使用率",
     "RPM": "当前RPM",
-    "TPM": "当前TPM"
+    "TPM": "当前TPM",
+    "availability": "可用率",
+    "status_normal": "正常",
+    "status_abnormal": "异常"
   },
   "analytics_index": {
     "startTime": "开始时间",

--- a/web/src/layout/MinimalLayout/Header/index.jsx
+++ b/web/src/layout/MinimalLayout/Header/index.jsx
@@ -37,7 +37,7 @@ const Header = () => {
   const [open, setOpen] = useState(null);
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const { t } = useTranslation();
-
+  const siteInfo = useSelector((state) => state.siteInfo);
   const handleOpenMenu = (event) => {
     setOpen(open ? null : event.currentTarget);
   };
@@ -141,6 +141,24 @@ const Header = () => {
             >
               {t('menu.about')}
             </Button>
+            {siteInfo.UptimeEnabled && (
+              <Button
+                component="a"
+                variant="text"
+                href={siteInfo.UptimeDomain}
+                target="_blank"
+                rel="noopener noreferrer"
+                color={pathname === '/status' ? 'primary' : 'inherit'}
+                sx={{
+                  fontSize: '0.875rem',
+                  fontWeight: 500,
+                  textTransform: 'none'
+                }}
+              >
+                {t('menu.status')}
+              </Button>
+            )}
+
             <NoticeButton sx={{ color: theme.palette.text.primary, ml: 1 }} />
             <ThemeButton sx={{ color: theme.palette.text.primary, ml: 0.5 }} />
             <I18nButton sx={{ color: theme.palette.text.primary, ml: 0.5 }} />
@@ -300,6 +318,28 @@ const Header = () => {
                         }
                       />
                     </ListItemButton>
+                    {siteInfo.UptimeEnabled && (
+                      <ListItemButton 
+                        component="a" 
+                        href={siteInfo.UptimeDomain}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <ListItemText
+                          primary={
+                            <Typography
+                              variant="body1"
+                              sx={{
+                                fontWeight: pathname === '/status' ? 500 : 400,
+                                color: pathname === '/status' ? theme.palette.primary.main : theme.palette.text.primary
+                              }}
+                            >
+                              {t('menu.status')}
+                            </Typography>
+                          }
+                        />
+                      </ListItemButton>
+                    )}
                     <Divider sx={{ my: 1 }} />
                     {account.user ? (
                       <ListItemButton

--- a/web/src/views/Dashboard/component/StatusPanel.jsx
+++ b/web/src/views/Dashboard/component/StatusPanel.jsx
@@ -1,0 +1,240 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Typography, Grid, Card, Divider, CircularProgress, Alert, IconButton, Chip } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { useTranslation } from 'react-i18next';
+import axios from 'axios';
+import RefreshIcon from '@mui/icons-material/Refresh';
+
+const StatusPanel = () => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const statusPageURL = '/api/user/dashboard/uptimekuma/status-page';
+  const statusPageHeartbeatURL = '/api/user/dashboard/uptimekuma/status-page/heartbeat';
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [statusData, setStatusData] = useState(null);
+  const [heartbeatData, setHeartbeatData] = useState(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Fetch status page data
+      const statusResponse = await axios.get(statusPageURL);
+      setStatusData(statusResponse.data);
+
+      // Fetch heartbeat data
+      const heartbeatResponse = await axios.get(statusPageHeartbeatURL);
+      setHeartbeatData(heartbeatResponse.data);
+
+      setLoading(false);
+    } catch (err) {
+      console.error('Error fetching status data:', err);
+      setError(err.message || 'Failed to fetch status data');
+      setLoading(false);
+    }
+  };
+
+  // Function to handle refresh
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [statusPageURL, statusPageHeartbeatURL]);
+
+  // Helper function to get the latest heartbeat status for a monitor
+  const getLatestHeartbeatStatus = (monitorId) => {
+    if (!heartbeatData || !heartbeatData.heartbeatList || !heartbeatData.heartbeatList[monitorId]) {
+      return null;
+    }
+
+    const heartbeats = heartbeatData.heartbeatList[monitorId];
+    return heartbeats.length > 0 ? heartbeats[heartbeats.length - 1] : null;
+  };
+
+  // Helper function to get uptime percentage for a monitor
+  const getUptimePercentage = (monitorId) => {
+    if (!heartbeatData || !heartbeatData.uptimeList) {
+      return null;
+    }
+
+    const uptimeKey = `${monitorId}_24`;
+    return heartbeatData.uptimeList[uptimeKey] !== undefined ? (heartbeatData.uptimeList[uptimeKey] * 100).toFixed(2) : null;
+  };
+
+  // Helper function to determine status color based on uptime percentage
+  const getStatusColor = (uptimePercentage) => {
+    if (uptimePercentage === null) return theme.palette.grey[500];
+    if (uptimePercentage >= 95) return theme.palette.success.main; // Green for high uptime
+    if (uptimePercentage > 90 && uptimePercentage < 95) return theme.palette.warning.main; // Warning for medium uptime
+    return theme.palette.error.main; // Error for low uptime
+  };
+  const getStatusToBgColor = (uptimePercentage) => {
+    if (uptimePercentage === null) return theme.palette.grey[500];
+    if (uptimePercentage >= 95) return theme.palette.success.lighter; // Green for high uptime
+    if (uptimePercentage > 90 && uptimePercentage < 95) return theme.palette.warning.light; // Warning for medium uptime
+    return theme.palette.error.light; // Error for low uptime
+  };
+
+  // Render status card for a monitor
+  const renderStatusCard = (monitor) => {
+    const latestStatus = getLatestHeartbeatStatus(monitor.id);
+    const uptimePercentage = getUptimePercentage(monitor.id);
+    const statusColor = getStatusColor(uptimePercentage);
+    const statusBgColor = getStatusToBgColor(uptimePercentage);
+    const isNormal = latestStatus && latestStatus.status === 1;
+
+    return (
+      <Grid item xs={12} sm={6} md={3} key={monitor.id}>
+        <Card
+          sx={{
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            backgroundColor: isNormal ? statusBgColor : theme.palette.error.lighter,
+            boxShadow: 'none',
+            borderRadius: 1,
+            p: 1.5,
+            border: `1px solid ${isNormal ? statusColor : theme.palette.error.main}`
+          }}
+        >
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Box
+                sx={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: '50%',
+                  backgroundColor: isNormal ? statusColor : theme.palette.error.main,
+                  mr: 1.5
+                }}
+              />
+              <Typography variant="subtitle1" component="div" sx={{ fontWeight: 500, color: '#333333' }}>
+                {monitor.name}
+              </Typography>
+            </Box>
+            <Box sx={{ marginLeft: 'auto' }}>
+              {monitor.tags &&
+                monitor.tags.map((tag, index) => (
+                  <Chip
+                    key={index}
+                    label={tag.value ? tag.value : tag.name}
+                    size="small"
+                    sx={{
+                      backgroundColor: tag.color,
+                      color: '#fff',
+                      ml: 0.3
+                    }}
+                  />
+                ))}
+            </Box>
+          </Box>
+
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography
+              variant="body1"
+              sx={{
+                color: isNormal ? statusColor : theme.palette.error.main,
+                fontWeight: 500
+              }}
+            >
+              {uptimePercentage}% {t('dashboard_index.availability')}
+            </Typography>
+          </Box>
+        </Card>
+      </Grid>
+    );
+  };
+
+  // Render content based on loading/error/data state
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+          <CircularProgress />
+        </Box>
+      );
+    }
+
+    if (error) {
+      return (
+        <Alert severity="error" sx={{ mt: 2 }}>
+          {error}
+        </Alert>
+      );
+    }
+
+    if (!statusData || !heartbeatData || !statusData.publicGroupList) {
+      return (
+        <Typography variant="body1" color="text.secondary" mt={2}>
+          {t('dashboard_index.no_data_available')}
+        </Typography>
+      );
+    }
+
+    return (
+      <Box mt={3}>
+        {statusData.publicGroupList.map((group) => (
+          <Box key={group.id} mb={4}>
+            <Typography variant="h5" gutterBottom>
+              {group.name}
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            <Grid container spacing={1.5}>
+              {group.monitorList.map((monitor) => renderStatusCard(monitor))}
+            </Grid>
+          </Box>
+        ))}
+      </Box>
+    );
+  };
+
+  return (
+    <Card>
+      <Box p={3}>
+        <Box display="flex" alignItems="center" mb={2}>
+          <Typography variant="h4" sx={{ mr: 1 }}>
+            {t('dashboard_index.tab_status')}
+          </Typography>
+          <IconButton
+            onClick={handleRefresh}
+            disabled={loading || refreshing}
+            size="small"
+            sx={{
+              p: 0.5,
+              '&:hover': {
+                backgroundColor: 'transparent'
+              }
+            }}
+          >
+            <RefreshIcon
+              fontSize="small"
+              sx={{
+                color: refreshing ? theme.palette.primary.main : theme.palette.text.secondary,
+                animation: refreshing ? 'spin 1s linear infinite' : 'none',
+                '@keyframes spin': {
+                  '0%': {
+                    transform: 'rotate(0deg)'
+                  },
+                  '100%': {
+                    transform: 'rotate(360deg)'
+                  }
+                }
+              }}
+            />
+          </IconButton>
+        </Box>
+        {renderContent()}
+      </Box>
+    </Card>
+  );
+};
+
+export default StatusPanel;

--- a/web/src/views/Dashboard/index.jsx
+++ b/web/src/views/Dashboard/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Grid, Box } from '@mui/material';
+import { Grid, Box, Stack, Typography, Button } from '@mui/material';
 import { gridSpacing } from 'store/constant';
 import StatisticalLineChartCard from './component/StatisticalLineChartCard';
 import ApexCharts from 'ui-component/chart/ApexCharts';
@@ -13,6 +13,29 @@ import InviteCard from './component/InviteCard';
 import QuotaLogWeek from './component/QuotaLogWeek';
 import QuickStartCard from './component/QuickStartCard';
 import RPM from './component/RPM';
+import StatusPanel from './component/StatusPanel';
+import { useSelector } from 'react-redux';
+
+// TabPanel component for tab content
+function TabPanel(props) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`dashboard-tabpanel-${index}`}
+      aria-labelledby={`dashboard-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box sx={{ pt: 3 }}>
+          {children}
+        </Box>
+      )}
+    </div>
+  );
+}
 
 const Dashboard = () => {
   const [isLoading, setLoading] = useState(true);
@@ -22,8 +45,14 @@ const Dashboard = () => {
   const [tokenChart, setTokenChart] = useState(null);
   const { t } = useTranslation();
   const [modelUsageData, setModelUsageData] = useState([]);
+  const [currentTab, setCurrentTab] = useState(0);
 
   const [dashboardData, setDashboardData] = useState(null);
+  const siteInfo = useSelector((state) => state.siteInfo);
+
+  const handleTabChange = (newValue) => {
+    setCurrentTab(newValue);
+  };
 
   const userDashboard = async () => {
     try {
@@ -52,7 +81,8 @@ const Dashboard = () => {
     userDashboard();
   }, []);
 
-  return (
+  // Dashboard content
+  const dashboardContent = (
     <Grid container spacing={gridSpacing}>
       {/* 支持的模型   */}
       <Grid item xs={12}>
@@ -122,6 +152,73 @@ const Dashboard = () => {
         </Grid>
       </Grid>
     </Grid>
+  );
+
+  return (
+    <>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" mb={1}>
+        <Stack direction="row" alignItems="center" spacing={3}>
+          <Stack direction="column" spacing={1}>
+            <Typography variant="h2">{t('dashboard_index.title')}</Typography>
+            <Typography variant="subtitle1" color="text.secondary">
+              Dashboard
+            </Typography>
+          </Stack>
+
+          {siteInfo.UptimeEnabled && (
+            <Stack direction="row" spacing={1}>
+              <Button 
+                onClick={() => handleTabChange(0)}
+                variant={currentTab === 0 ? "contained" : "text"}
+                size="small"
+                disableElevation
+                sx={{
+                  padding: '6px 16px',
+                  borderRadius: '4px',
+                  backgroundColor: currentTab === 0 ? 'primary.main' : 'transparent',
+                  color: currentTab === 0 ? 'white' : 'text.primary',
+                  '&:hover': {
+                    backgroundColor: currentTab === 0 ? 'primary.dark' : 'action.hover'
+                  }
+                }}
+              >
+                {t('dashboard_index.tab_dashboard')}
+              </Button>
+              <Button 
+                onClick={() => handleTabChange(1)}
+                variant={currentTab === 1 ? "contained" : "text"}
+                size="small"
+                disableElevation
+                sx={{
+                  padding: '6px 16px',
+                  borderRadius: '4px',
+                  backgroundColor: currentTab === 1 ? 'primary.main' : 'transparent',
+                  color: currentTab === 1 ? 'white' : 'text.primary',
+                  '&:hover': {
+                    backgroundColor: currentTab === 1 ? 'primary.dark' : 'action.hover'
+                  }
+                }}
+              >
+                {t('dashboard_index.tab_status')}
+              </Button>
+            </Stack>
+          )}
+        </Stack>
+      </Stack>
+
+      {siteInfo.UptimeEnabled ? (
+        <>
+          <TabPanel value={currentTab} index={0}>
+            {dashboardContent}
+          </TabPanel>
+          <TabPanel value={currentTab} index={1}>
+            <StatusPanel />
+          </TabPanel>
+        </>
+      ) : (
+        dashboardContent
+      )}
+    </>
   );
 };
 

--- a/web/src/views/Log/index.jsx
+++ b/web/src/views/Log/index.jsx
@@ -209,6 +209,11 @@ export default function Log() {
             variant="scrollable"
             scrollButtons="auto"
             allowScrollButtonsMobile
+            sx={{
+              '& .MuiTabs-indicator': {
+                display: 'none'
+              }
+            }}
           >
             {Object.values(LogType).map((option) => {
               return <Tab key={option.value} label={option.text} value={option.value} />;

--- a/web/vite.config.mjs
+++ b/web/vite.config.mjs
@@ -32,7 +32,7 @@ export default defineConfig({
     port: 3010,
     proxy: {
       '/api': {
-        target: 'http://127.0.0.1:3001', // 设置代理的目标服务器
+        target: 'http://127.0.0.1:3000', // 设置代理的目标服务器
         changeOrigin: true
       }
     }


### PR DESCRIPTION
新增对Uptime Kuma状态展示的支持，包括状态页面和心跳数据的集成，以及前端和后端的相关组件与配置。

- 在仪表盘新增状态面板Tab，用于展示Uptime Kuma数据。
- 后端增加状态页面和心跳数据接口。
- 新增配置选项以支持Uptime Kuma相关功能。
具体使用详见配置文件：
```
uptime_kuma:
  enable: false # 是否开启uptime kuma状态展示
  domain: ""     # uptime-kuma项目地址 例如https://status.xxxxx.com
  status_page_name: "" #  uptime-kuma状态页面slug
```

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/35f7605a-fc49-4065-a6a2-1bcb58f01163)
![image](https://github.com/user-attachments/assets/843ab2c3-aa38-47b5-af56-0f613b3c1cd9)

