### PR TITLE
feat(github-provider): 实现获取模型列表功能

### DIFF
--- a/providers/github/base.go
+++ b/providers/github/base.go
@@ -29,6 +29,7 @@ func getGithubConfig() base.ProviderConfig {
 		BaseURL:         "https://models.inference.ai.azure.com",
 		ChatCompletions: "/chat/completions",
 		Embeddings:      "/embeddings",
+		ModelList:       "/models",
 	}
 }
 

--- a/providers/github/model.go
+++ b/providers/github/model.go
@@ -1,0 +1,29 @@
+package github
+
+import (
+	"errors"
+	"net/http"
+)
+
+func (p *GithubProvider) GetModelList() ([]string, error) {
+	fullRequestURL := p.GetFullRequestURL(p.Config.ModelList, "")
+	headers := p.GetRequestHeaders()
+
+	req, err := p.Requester.NewRequest(http.MethodGet, fullRequestURL, p.Requester.WithHeader(headers))
+	if err != nil {
+		return nil, errors.New("new_request_failed")
+	}
+
+	var response ModelListResponse
+	_, errWithCode := p.Requester.SendRequest(req, &response, false)
+	if errWithCode != nil {
+		return nil, errors.New(errWithCode.Message)
+	}
+
+	var modelList []string
+	for _, model := range response {
+		modelList = append(modelList, model.Name)
+	}
+
+	return modelList, nil
+}

--- a/providers/github/type.go
+++ b/providers/github/type.go
@@ -1,0 +1,18 @@
+package github
+
+type ModelListResponse []ModelInfo
+
+type ModelInfo struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	FriendlyName  string   `json:"friendly_name"`
+	ModelVersion  int      `json:"model_version"`
+	Publisher     string   `json:"publisher"`
+	ModelFamily   string   `json:"model_family"`
+	ModelRegistry string   `json:"model_registry"`
+	License       string   `json:"license"`
+	Task          string   `json:"task"`
+	Description   string   `json:"description"`
+	Summary       string   `json:"summary"`
+	Tags          []string `json:"tags"`
+}

--- a/web/src/views/Channel/type/Config.js
+++ b/web/src/views/Channel/type/Config.js
@@ -473,6 +473,9 @@ const typeConfig = {
       models: ['gpt-4o', 'gpt-4o-mini', 'text-embedding-3-large', 'text-embedding-3-small', 'Cohere-command-r-plus', 'Cohere-command-r'],
       test_model: 'gpt-4o-mini'
     },
+    inputLabel: {
+      provider_models_list: '从Github获取模型列表'
+    },
     prompt: {
       key: '密钥信息请参考https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens',
       base_url: 'https://models.inference.ai.azure.com'


### PR DESCRIPTION
新增通过Github获取模型列表的功能，包括相关的请求逻辑和数据结构。

- 添加GetModelList方法，用于发送HTTP请求获取模型列表
- 定义ModelListResponse及ModelInfo数据结构
- 更新GithubProvider配置，新增ModelList字段
- 修改前端配置，支持展示Github提供的模型列表标签

