### PR TITLE
feat: 模型选择器功能完善

### DIFF
--- a/web/src/i18n/locales/en_US.json
+++ b/web/src/i18n/locales/en_US.json
@@ -139,7 +139,15 @@
     "removePrefix": "Remove prefix",
     "removeSuffix": "Remove suffix",
     "collapseList": "Collapse list",
-    "expandList": "Expand list"
+    "expandList": "Expand list",
+    "convertToLowercase": "Convert model names to lowercase",
+    "filterMappedModels": "Do not fill the model name before mapping.",
+    "overwriteModels": "Overwrite existing model list",
+    "overwriteModelsTip": "When enabled, the existing model list will be cleared and only the selected models will be preserved",
+    "overwriteMappings": "Overwrite existing mappings",
+    "overwriteMappingsTip": "When enabled, existing mappings will be cleared and only new mappings will be preserved",
+    "clearModels": "Reset",
+    "clearModelsTip": "Reset all selected models"
   },
   "channel_index": {
     "AzureApiVersion": "Azure version number",
@@ -279,6 +287,7 @@
     "processing": "Processing...",
     "registerOk": "registration success!",
     "registerTip": "The verification code was sent successfully, please check your email!",
+    "reset": "Reset",
     "saveSuccess": "Saved successfully!",
     "serverError": "Server Error",
     "show": "show",

--- a/web/src/i18n/locales/zh_CN.json
+++ b/web/src/i18n/locales/zh_CN.json
@@ -228,7 +228,15 @@
     "removePrefix": "删除前缀",
     "removeSuffix": "删除后缀",
     "collapseList": "收起列表",
-    "expandList": "展开列表"
+    "expandList": "展开列表",
+    "convertToLowercase": "模型名称转小写",
+    "filterMappedModels": "不填充映射前的模型名称",
+    "overwriteModels": "覆盖原有模型列表",
+    "overwriteModelsTip": "启用后将清空原有的模型列表，仅保留此次选择的模型",
+    "overwriteMappings": "覆盖原有映射关系",
+    "overwriteMappingsTip": "启用后将清空原有的映射关系，仅保留此次创建的映射",
+    "clearModels": "重置",
+    "clearModelsTip": "重置所有已选择的模型"
   },
   "token_index": {
     "token": "令牌",
@@ -1057,6 +1065,7 @@
     "back": "返回",
     "none": "无",
     "show": "显示",
+    "reset": "重置",
     "copyUrl": "复制地址",
     "downImg": "下载图片",
     "newWindos": "新窗口打开",


### PR DESCRIPTION
- 在`en_US.json`和`zh_CN.json`中添加了多个新翻译项，包括“转换为小写”、“覆盖模型列表”、“重置”等。
- 在`EditModal.jsx`和`ModelSelectorModal.jsx`中实现了模型选择器的覆盖和追加模式功能，支持用户选择模型时的不同操作方式。
- 增加了相关的提示信息和功能开关，以提升用户体验和操作灵活性。

我已确认该 PR 已自测通过，相关截图如下：

1. 支持在模型选择器重置所有已选模型

![image](https://github.com/user-attachments/assets/92213d30-cd70-40b8-9ea8-a8d1289f666b)

2. 支持直接覆盖编辑框里选择的模型列表
3. 支持在设置模型映射时：模型名称转小写
4. 支持在设置模型映射时：不填充映射前的模型名称
5. 支持在设置模型映射时：覆盖编辑器中原有映射关系

![image](https://github.com/user-attachments/assets/b3ccdd38-66cb-4e39-9364-906568ed9cff)
