### PR TITLE
fix(relay): correct model name formatting in Gemini channel

### DIFF
--- a/relay/model.go
+++ b/relay/model.go
@@ -93,7 +93,7 @@ func ListGeminiModelsByToken(c *gin.Context) {
 		price := model.PricingInstance.GetPrice(modelName)
 		if price.ChannelType == config.ChannelTypeGemini {
 			geminiModels = append(geminiModels, gemini.ModelDetails{
-				Name: modelName,
+				Name: fmt.Sprintf("models/%s", modelName),
 			})
 		}
 	}


### PR DESCRIPTION
Updated the model name formatting to include a "models/" prefix in the Gemini channel type assignment.

