### PR TITLE
fix(limit): 检查Redis配置以避免获取实时RPM时出错

### DIFF
--- a/common/limit/countlimit.go
+++ b/common/limit/countlimit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"one-api/common/config"
 	"one-api/common/redis"
 	"time"
 )
@@ -45,8 +46,10 @@ func (l *CountLimiter) AllowN(keyPrefix string, n int) bool {
 }
 
 func (l *CountLimiter) GetCurrentRate(keyPrefix string) (int, error) {
+	if !config.RedisEnabled {
+		return 0, fmt.Errorf("Redis未配置，API限速功能未生效，无法获取实时RPM")
+	}
 	countKey := fmt.Sprintf(countFormat, keyPrefix)
-
 	result, err := redis.ScriptRunCtx(context.Background(),
 		countGetScript,
 		[]string{

--- a/common/limit/slidingwindow.go
+++ b/common/limit/slidingwindow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"one-api/common/config"
 	"one-api/common/redis"
 	"time"
 )
@@ -50,6 +51,9 @@ func (l *SlidingWindowLimiter) AllowN(keyPrefix string, n int) bool {
 
 // GetCurrentRate 获取当前速率
 func (l *SlidingWindowLimiter) GetCurrentRate(keyPrefix string) (int, error) {
+	if !config.RedisEnabled {
+		return 0, fmt.Errorf("Redis未配置，API限速功能未生效，无法获取实时RPM")
+	}
 	slidingKey := fmt.Sprintf(slidingWindowFormat, keyPrefix)
 	nowSec := time.Now().Unix()
 

--- a/common/limit/tokenlimit.go
+++ b/common/limit/tokenlimit.go
@@ -25,6 +25,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"one-api/common/config"
 	"one-api/common/logger"
 	"one-api/common/redis"
 	"strconv"
@@ -77,6 +78,9 @@ func (lim *TokenLimiter) AllowN(keyPrefix string, n int) bool {
 
 // GetCurrentRate 获取当前速率使用情况，返回已使用的速率
 func (lim *TokenLimiter) GetCurrentRate(keyPrefix string) (int, error) {
+	if !config.RedisEnabled {
+		return 0, fmt.Errorf("Redis未配置，API限速功能未生效，无法获取实时RPM")
+	}
 	tokenKey := fmt.Sprintf(tokenFormat, keyPrefix)
 	timestampKey := fmt.Sprintf(timestampFormat, keyPrefix)
 	counterKey := fmt.Sprintf(counterFormat, keyPrefix)


### PR DESCRIPTION
修复API限速器在Redis未配置情况下获取实时速率的问题。添加Redis配置检查逻辑并更新速率获取方法。

- 针对CountLimiter、SlidingWindowLimiter和TokenLimiter增加RedisEnabled判断
- 提供明确的错误提示，提高问题诊断效率

