### PR TITLE
chore(workflow): 更新Go设置版本及构建工具依赖

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,9 +52,9 @@ jobs:
           VITE_APP_VERSION=$VERSION yarn run build
           cd ..
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: ">=1.18.0"
+          go-version: "1.24.2"
       - name: Cache Go modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -27,9 +27,9 @@ jobs:
           VITE_APP_VERSION=$(git describe --tags) yarn run build
           cd ..
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: ">=1.18.0"
+          go-version: "1.24.2"
       - name: Build Backend (amd64)
         run: |
           go mod download

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -27,9 +27,9 @@ jobs:
           VITE_APP_VERSION=$(git describe --tags) yarn run build
           cd ..
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: ">=1.18.0"
+          go-version: "1.24.2"
       - name: Build Backend
         run: |
           go mod download

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -30,9 +30,9 @@ jobs:
           VITE_APP_VERSION=$(git describe --tags) npm run build
           cd ..
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: ">=1.18.0"
+          go-version: "1.24.2"
       - name: Build Backend
         run: |
           go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY ./web .
 COPY ./VERSION .
 RUN DISABLE_ESLINT_PLUGIN='true' VITE_APP_VERSION=$(cat VERSION) npm run build
 
-FROM golang:1.24 AS builder2
+FROM golang:1.24.2 AS builder2
 
 ENV GO111MODULE=on \
     CGO_ENABLED=1 \


### PR DESCRIPTION
更新多个GitHub Actions工作流中的Go版本配置，从">=1.18.0"调整为"1.24.2"以匹配最新需求。

- 更新了windows-release.yml、macos-release.yml、linux-release.yml等文件中actions/setup-go依赖版本至v4。
- Dockerfile中基础镜像版本从golang:1.24更新为golang:1.24.2。

此更新提升了构建脚本的依赖一致性及最新版本兼容性。


