### PR TITLE
style(web): 调整ModelPrice页面“供应商”的对齐方式

### DIFF
--- a/web/src/views/ModelPrice/index.jsx
+++ b/web/src/views/ModelPrice/index.jsx
@@ -636,7 +636,7 @@ export default function ModelPrice() {
                       </Stack>
                     </TableCell>
                     <TableCell sx={{ py: 1.5 }}>
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Box sx={{ display: 'flex',  alignItems: 'center', gap: 1, justifyContent: 'center' }}>
                         <Avatar
                           src={getIconByName(row.provider)}
                           alt={row.provider}


### PR DESCRIPTION
将表格单元格中的内容居中显示，提升视觉一致性

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/6da9b230-6ef3-4cc8-b36f-9ab804fa7f62)
