### PR TITLE
feat(gemini): show grouding google search

### DIFF
--- a/providers/gemini/type.go
+++ b/providers/gemini/type.go
@@ -167,7 +167,7 @@ func (candidate *GeminiChatCandidate) ToOpenAIStreamChoice(request *types.ChatCo
 	if candidate.GroundingMetadata != nil && showGoogleSearchMeta(request) {
 		groundingMarkdown := formatGroundingMetadataAsMarkdown(candidate.GroundingMetadata)
 		if groundingMarkdown != "" {
-			content = append(content, groundingMarkdown)
+			content = append(content, "\n\n" + groundingMarkdown)
 		}
 	}
 


### PR DESCRIPTION
gemini开启了google search之后，会在返回的最后一个candidate里增加search query的相关信息，这个在ai studio里面可以展现出来。  
这个pr实现中，function扩展了`"parameter"="show"`，可以在回复的最后，使用引用格式来列出search results。

```
 curl http://localhost:13333/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $SELF_API_KEY" \
  -d '{
    "model": "gemini-2.5-flash",
    "stream": false,
    "tools": [{"type": "function", "function": {"name": "googleSearch", "parameters": "show"}}],
    "messages": [
      {
        "role": "user",
        "content": "今天北京天气"
      }
    ]
  }'
```

我已确认该 PR 已自测通过，相关截图如下：

![image](https://github.com/user-attachments/assets/b0102d5c-0c4e-4d8d-878a-2352345238f2)

