### PR TITLE
fix(session): 增加会话存储选项配置支持

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	"fmt"
+	"net/http"
 	"one-api/cli"
 	"one-api/common"
 	"one-api/common/cache"
@@ -128,6 +129,13 @@ func initHttpServer() {
 	}
 
 	store := cookie.NewStore([]byte(config.SessionSecret))
+	store.Options(sessions.Options{
+		Path:     "/",
+		MaxAge:   2592000, // 30 days
+		HttpOnly: true,
+		Secure:   false,
+		SameSite: http.SameSiteStrictMode,
+	})
 	server.Use(sessions.Sessions("session", store))
 
 	router.SetRouter(server, buildFS, indexPage)


### PR DESCRIPTION
- 配置了session存储选项，支持设置路径、有效期等参数。
- 支持HttpOnly、Secure及SameSite选项用于增强会话安全性。

提升了会话管理的灵活性和安全性。

close #757


![image](https://github.com/user-attachments/assets/8add185d-539f-4845-a647-f68bb9056896)
