### PR TITLE
refactor(token): 优化密钥日志记录及令牌缓存验证逻辑

### DIFF
--- a/middleware/rate-limit.go
+++ b/middleware/rate-limit.go
@@ -19,10 +19,10 @@ var inMemoryRateLimiter common.InMemoryRateLimiter
 // All duration's unit is seconds
 // Shouldn't larger then RateLimitKeyExpirationDuration
 var (
-	GlobalApiRateLimitNum            = 180
+	GlobalApiRateLimitNum            = 300
 	GlobalApiRateLimitDuration int64 = 3 * 60
 
-	GlobalWebRateLimitNum            = 100
+	GlobalWebRateLimitNum            = 180
 	GlobalWebRateLimitDuration int64 = 3 * 60
 
 	UploadRateLimitNum            = 10

--- a/model/statistics_month.go
+++ b/model/statistics_month.go
@@ -263,8 +263,11 @@ func GetUserInvoices(params *StatisticsMonthSearchParams) (*DataResult[Statistic
 		}
 	}
 
-	// Apply the validated order
-	query = query.Order(orderField + " " + orderDir)
+	if orderDir == "DESC" {
+		query = query.Order(fmt.Sprintf("%s DESC", orderField))
+	} else {
+		query = query.Order(fmt.Sprintf("%s ASC", orderField))
+	}
 
 	// Apply pagination
 	query = query.Limit(params.Size).Offset(offset)

--- a/model/token.go
+++ b/model/token.go
@@ -3,6 +3,7 @@ package model
 import (
 	"errors"
 	"fmt"
+	"gorm.io/gorm"
 	"one-api/common"
 	"one-api/common/config"
 	"one-api/common/database"
@@ -10,8 +11,6 @@ import (
 	"one-api/common/redis"
 	"one-api/common/stmp"
 	"one-api/common/utils"
-
-	"gorm.io/gorm"
 )
 
 var (
@@ -114,7 +113,8 @@ func GetTokenModel(key string) (token *Token, err error) {
 
 	token, err = CacheGetTokenByKey(key)
 	if err != nil {
-		logger.SysError(fmt.Sprintf("DB Not Found: userId=%d, tokenId=%d, key=%s, err=%s", userId, tokenId, key, err.Error()))
+		maskedKey := key[:3] + "*********" + key[len(key)-3:]
+		logger.SysError(fmt.Sprintf("DB Not Found: userId=%d, tokenId=%d, key=%s, err=%s", userId, tokenId, maskedKey, err.Error()))
 		return nil, ErrTokenInvalid
 	}
 


### PR DESCRIPTION
fix(token): 优化密钥日志记录及令牌缓存验证逻辑

- 避免在日志中暴露完整密钥，增加键值屏蔽处理 (`key[:3] + ********* + key[len(key)-3:]`)。
- 缓存令牌验证处理逻辑进行了调整，改进了用户令牌失效时的错误处理。

---

refactor(limit): 调整全局API访问及Web访问限流设置

- 提升全局API限流：默认值从180次调整为300次。
- 提升全局Web限流：默认值从100次调整为180次。

这一改动主要减少dashboard升级后api请求比较多导致429的问题。
⚠️建议用户自行通过环境变量按照自己的使用需求设置这两个参数而不是使用默认值。

---

fix(statistics): 修复月度统计排序时的字段拼接问题

- 修改排序拼接逻辑，确保字段及排序方向动态生成，避免潜在的SQL注入风险。
- 当排序方向为`DESC`时拼接`orderField DESC`，否则拼接`orderField ASC`。

---

feat(system-logs): 增加组件初始化标志以精确控制日志获取逻辑

- 引入`isInitialized`状态，避免组件初始化阶段重复触发日志加载。
- 确保最大条目数更改时能够精确响应，并避免初始渲染时的重复动作。
- 在启用自动刷新时，确保前置校验组件状态是否完成初始化。

调整后显著改善了日志组件初始加载性能，同时提升了刷新逻辑的严谨性。


