### PR TITLE
feat(relay): 增加Gemini Model显示名称支持

### DIFF
--- a/providers/gemini/type.go
+++ b/providers/gemini/type.go
@@ -573,6 +573,7 @@ type ModelListResponse struct {
 
 type ModelDetails struct {
 	Name                       string   `json:"name"`
+	DisplayName                string   `json:"displayName"`
 	SupportedGenerationMethods []string `json:"supportedGenerationMethods"`
 }
 

--- a/relay/model.go
+++ b/relay/model.go
@@ -2,6 +2,8 @@ package relay
 
 import (
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"net/http"
 	"one-api/common"
 	"one-api/common/config"
@@ -11,6 +13,7 @@ import (
 	"one-api/providers/gemini"
 	"one-api/types"
 	"sort"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -93,7 +96,9 @@ func ListGeminiModelsByToken(c *gin.Context) {
 		price := model.PricingInstance.GetPrice(modelName)
 		if price.ChannelType == config.ChannelTypeGemini {
 			geminiModels = append(geminiModels, gemini.ModelDetails{
-				Name: fmt.Sprintf("models/%s", modelName),
+				Name:                       fmt.Sprintf("models/%s", modelName),
+				DisplayName:                cases.Title(language.Und).String(strings.ReplaceAll(modelName, "-", " ")),
+				SupportedGenerationMethods: []string{},
 			})
 		}
 	}


### PR DESCRIPTION
- 新增`DisplayName`字段，使用标题化处理为模型名称生成更友好的显示名称。
- 引入`golang.org/x/text/cases`与`strings.ReplaceAll`库，用于名称格式化。
- 优化Gemini模型详细信息构建逻辑，提高可读性和易用性。

此更新旨在改善用户界面模型名称的显示效果。

我已确认该 PR 已自测通过，相关截图如下：
![image](https://github.com/user-attachments/assets/0b59c830-640d-4dd4-812a-e00b3c0350e6)

