### PR TITLE
style(Channel/TableRow): 移除多余的maxWidth样式属性

### DIFF
--- a/web/src/views/Channel/component/TableRow.jsx
+++ b/web/src/views/Channel/component/TableRow.jsx
@@ -345,7 +345,6 @@ export default function ChannelTableRow({ item, manageChannel, onRefresh, groupO
               variant="subtitle1"
               sx={{
                 color: 'primary.main',
-                maxWidth: 100,
                 display: 'block'
               }}
             >
@@ -355,7 +354,6 @@ export default function ChannelTableRow({ item, manageChannel, onRefresh, groupO
             <Typography
               variant="subtitle1"
               sx={{
-                maxWidth: 100,
                 lineHeight: 1.4
               }}
             >


### PR DESCRIPTION
我已确认该 PR 已自测通过，相关截图如下：

修改前
<img width="578" height="283" alt="QQ20250715-140514" src="https://github.com/user-attachments/assets/191340a5-bd5f-46aa-a9a9-c4772e8ac218" />

修改后
<img width="584" height="278" alt="QQ20250716-090012" src="https://github.com/user-attachments/assets/c531c1bf-e741-4314-9fbf-ca133fa00ee9" />

