### PR TITLE
style: 移除多余的padding样式属性，并居中图标

### DIFF
--- a/web/src/themes/compStyleOverride.js
+++ b/web/src/themes/compStyleOverride.js
@@ -495,11 +495,9 @@ export default function componentStyleOverrides(theme) {
             width: '100%',
             '& th:first-of-type': {
               borderTopLeftRadius: 0,
-              paddingLeft: '24px'
             },
             '& th:last-of-type': {
               borderTopRightRadius: 0,
-              paddingRight: '24px'
             }
           }
         }

--- a/web/src/ui-component/IconWrapper.jsx
+++ b/web/src/ui-component/IconWrapper.jsx
@@ -9,6 +9,7 @@ const IconWrapperStyled = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  margin: 'auto',
   backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 1)' : 'transparent',
   '& img': {
     width: '20px',


### PR DESCRIPTION
我已确认该 PR 已自测通过，相关截图如下：

修改前
<img width="1294" height="319" alt="QQ20250716-143241" src="https://github.com/user-attachments/assets/2c069097-4843-4012-af3d-834aba7b2809" />

修改后
<img width="1301" height="320" alt="QQ20250716-151043" src="https://github.com/user-attachments/assets/a199ff92-fe9e-417f-bfe2-fc7927d4f354" />
