### PR TITLE
Web authn

### DIFF
--- a/controller/webauthn.go
+++ b/controller/webauthn.go
@@ -165,7 +165,7 @@ func WebauthnBeginLogin(c *gin.Context) {
 	err = user.FillUserByUsername()
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
-			"message": "用户不存在",
+			"message": "登陆失败",
 			"success": false,
 		})
 		return
@@ -227,7 +227,7 @@ func WebauthnFinishLogin(c *gin.Context) {
 	userId, err := strconv.Atoi(userIdStr.(string))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
-			"message": "用户ID解析失败",
+			"message": "登陆失败",
 			"success": false,
 		})
 		return
@@ -236,7 +236,7 @@ func WebauthnFinishLogin(c *gin.Context) {
 	user, err := model.GetUserById(userId, false)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
-			"message": "用户不存在",
+			"message": "登陆失败",
 			"success": false,
 		})
 		return
@@ -264,7 +264,7 @@ func WebauthnFinishLogin(c *gin.Context) {
 	// 检查用户状态
 	if user.Status != 1 {
 		c.JSON(http.StatusForbidden, gin.H{
-			"message": "用户已被封禁",
+			"message": "登陆失败",
 			"success": false,
 		})
 		return

--- a/model/user.go
+++ b/model/user.go
@@ -603,6 +603,7 @@ type WebAuthnCredential struct {
 	CredentialId    string `json:"credential_id" gorm:"type:varbinary(255);uniqueIndex"` // 使用 varbinary
 	PublicKey       []byte `json:"public_key"`
 	AttestationType string `json:"attestation_type"`
+	Alias           string `json:"alias" gorm:"type:varchar(255);default:''"`
 	// Persist essential authenticator state and flags used during login validation
 	BackupEligible bool                   `json:"backup_eligible" gorm:"column:backup_eligible;default:false"`
 	BackupState    bool                   `json:"backup_state" gorm:"column:backup_state;default:false"`
@@ -645,13 +646,17 @@ func GetUserWebAuthnCredentials(userId int) []webauthn.Credential {
 }
 
 // 保存WebAuthn凭据
-func SaveWebAuthnCredential(userId int, credential *webauthn.Credential) error {
+func SaveWebAuthnCredential(userId int, credential *webauthn.Credential, alias string) error {
+	if alias == "" {
+		alias = time.Now().Format("2006-01-02 15:04:05")
+	}
 	credentialIdBase64 := base64.StdEncoding.EncodeToString(credential.ID)
 	webauthnCred := WebAuthnCredential{
 		UserId:          userId,
 		CredentialId:    credentialIdBase64,
 		PublicKey:       credential.PublicKey,
 		AttestationType: credential.AttestationType,
+		Alias:           alias,
 		BackupEligible:  credential.Flags.BackupEligible,
 		BackupState:     credential.Flags.BackupState,
 		Authenticator:   credential.Authenticator,

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -53,8 +53,8 @@ func SetApiRouter(router *gin.Engine) {
 			webauthnGroup.POST("/registration/finish", middleware.UserAuth(), controller.WebauthnFinishRegistration)
 
 			// 登录相关
-			webauthnGroup.POST("/login/begin", controller.WebauthnBeginLogin)
-			webauthnGroup.POST("/login/finish", controller.WebauthnFinishLogin)
+			webauthnGroup.POST("/login/begin", middleware.CriticalRateLimit(), controller.WebauthnBeginLogin)
+			webauthnGroup.POST("/login/finish", middleware.CriticalRateLimit(), controller.WebauthnFinishLogin)
 
 			// 凭据管理
 			webauthnGroup.GET("/credentials", middleware.UserAuth(), controller.GetUserWebAuthnCredentials)

--- a/web/src/utils/common.jsx
+++ b/web/src/utils/common.jsx
@@ -283,7 +283,7 @@ export async function onWebAuthnClicked(username, showError, showSuccess, naviga
   }
 }
 
-export async function onWebAuthnRegister(showError, showSuccess, onSuccess) {
+export async function onWebAuthnRegister(showError, showSuccess, onSuccess, alias = '') {
   try {
     // 检查浏览器是否支持WebAuthn
     if (!window.PublicKeyCredential) {
@@ -297,7 +297,8 @@ export async function onWebAuthnRegister(showError, showSuccess, onSuccess) {
       headers: {
         'Content-Type': 'application/json',
         Authorization: localStorage.getItem('token')
-      }
+      },
+      body: JSON.stringify({ alias })
     });
 
     const beginData = await beginResponse.json();


### PR DESCRIPTION
feat(webauthn): 增加凭据别名支持及优化注册流程

- 为WebAuthn注册功能增加凭据别名支持，用户可选填易于识别的别名。
- 更新前端UI，添加别名输入对话框，支持快捷操作及提示信息。
- 后端扩展相关数据库模型，保存并返回别名字段。
- 优化控制器逻辑，确保会话别名存储及传递安全性。

此更新优化了用户体验，简化了对凭据的管理与识别流程。