### PR TITLE
Add support for an "Images" field in the response sent to users. 

### DIFF
--- a/types/chat.go
+++ b/types/chat.go
@@ -57,6 +57,7 @@ type ChatCompletionMessage struct {
 	Audio            any                              `json:"audio,omitempty"`
 	Annotations      any                              `json:"annotations,omitempty"`
 	Image            []MultimediaData                 `json:"image,omitempty"`
+	Images           []ChatMessagePart                `json:"images,omitempty"`
 }
 
 func (m ChatCompletionMessage) StringContent() string {
@@ -396,6 +397,7 @@ type ChatCompletionStreamChoiceDelta struct {
 	ReasoningContent string                           `json:"reasoning_content,omitempty"`
 	Reasoning        string                           `json:"reasoning,omitempty"`
 	Image            []MultimediaData                 `json:"image,omitempty"`
+	Images           []ChatMessagePart                `json:"images,omitempty"`
 }
 
 func (m *ChatCompletionStreamChoiceDelta) ToolToFuncCalls() {


### PR DESCRIPTION
在响应中增加 "Images" 字段支持，使 OpenRouter 的 Gemini 2.5 Flash Image 模型的图像输出可以正常返回给用户。