### PR TITLE
refactor(i18n): 统一WebAuthn相关文本多语言支持 (#817)

### DIFF
--- a/web/src/i18n/locales/en_US.json
+++ b/web/src/i18n/locales/en_US.json
@@ -745,7 +745,15 @@
     "usernameMinLength": "Username must be at least 3 characters long",
     "usernameRequired": "Username cannot be empty",
     "wechatBindSuccess": "WeChat account successfully bound!",
-    "yourTokenIs": "Your access token is:"
+    "yourTokenIs": "Your access token is:",
+    "registerWebauthn": "Register WebAuthn Credential",
+    "webauthnManagement": "WebAuthn Credential Management",
+    "webauthnDescription": "WebAuthn provides passwordless authentication, allowing you to log in using biometric methods like fingerprints, Face ID, or security keys.",
+    "registeredCredentials": "Registered Credentials",
+    "alias": "Alias:",
+    "credentialId": "Credential ID:",
+    "registerTime": "Register Time:",
+    "delete": "Delete"
   },
   "redemption": "Redemption",
   "redemptionPage": {

--- a/web/src/i18n/locales/ja_JP.json
+++ b/web/src/i18n/locales/ja_JP.json
@@ -733,7 +733,15 @@
     "usernameMinLength": "ユーザー名は3文字以上でなければなりません",
     "usernameRequired": "ユーザー名は空にできません",
     "wechatBindSuccess": "WeChatアカウントのバインドに成功しました！",
-    "yourTokenIs": "あなたのアクセストークンは次の通りです："
+    "yourTokenIs": "あなたのアクセストークンは次の通りです：",
+    "registerWebauthn": "WebAuthn認証を登録",
+    "webauthnManagement": "WebAuthn資格情報の管理",
+    "webauthnDescription": "WebAuthnはパスワードレス認証を提供し、指紋認証、Face ID、セキュリティキーなどの生体認証を使用してログインできます。",
+    "registeredCredentials": "登録済み認証情報",
+    "alias": "エイリアス:",
+    "credentialId": "認証情報ID:",
+    "registerTime": "登録日時:",
+    "delete": "削除"
   },
   "redemption": "引き換え",
   "redemptionPage": {

--- a/web/src/i18n/locales/zh_CN.json
+++ b/web/src/i18n/locales/zh_CN.json
@@ -560,7 +560,15 @@
     "lark": "飞书",
     "tokenNotice": "注意，此处生成的令牌用于系统管理，而非用于请求 OpenAI 相关的服务，请知悉。",
     "yourTokenIs": "你的访问令牌是:",
-    "keepSafe": "请妥善保管。如有泄漏，请立即重置。"
+    "keepSafe": "请妥善保管。如有泄漏，请立即重置。",
+    "registerWebauthn": "注册WebAuthn凭证",
+    "webauthnManagement":"WebAuthn 凭据管理",
+    "webauthnDescription": "WebAuthn 提供无密码身份验证，您可以使用指纹、Face ID 或安全密钥等生物识别方式进行登录。",
+    "registeredCredentials": "已注册凭证",
+    "alias": "别名:",
+    "credentialId": "凭据 ID:",
+    "registerTime": "注册时间:",
+    "delete": "删除"
   },
   "pricingPage": {
     "title": "模型价格",

--- a/web/src/i18n/locales/zh_HK.json
+++ b/web/src/i18n/locales/zh_HK.json
@@ -734,7 +734,15 @@
     "usernameMinLength": "用戶名不能少於 3 個字符",
     "usernameRequired": "用戶名不能為空",
     "wechatBindSuccess": "微信帳戶綁定成功！",
-    "yourTokenIs": "你的訪問令牌是："
+    "yourTokenIs": "你的訪問令牌是：",
+    "registerWebauthn": "註冊 WebAuthn 憑證",
+    "webauthnManagement": "WebAuthn 憑證管理",
+    "webauthnDescription": "WebAuthn 提供無密碼身份驗證，您可以使用指紋、Face ID 或安全密鑰等生物識別方式進行登入。",
+    "registeredCredentials": "已註冊憑證",
+    "alias": "別名:",
+    "credentialId": "憑證 ID:",
+    "registerTime": "註冊時間:",
+    "delete": "刪除"
   },
   "redemption": "兌換",
   "redemptionPage": {

--- a/web/src/views/Authentication/AuthForms/AuthLogin.jsx
+++ b/web/src/views/Authentication/AuthForms/AuthLogin.jsx
@@ -302,12 +302,14 @@ const LoginForm = ({ ...others }) => {
                 <Button
                   disableElevation
                   fullWidth
-                  onClick={() => onWebAuthnClicked(
-                    values.username,
-                    (msg) => setErrors({ submit: msg }),
-                    (msg) => setStatus({ success: true, message: msg }),
-                    () => {}
-                  )}
+                  onClick={() =>
+                    onWebAuthnClicked(
+                      values.username,
+                      (msg) => setErrors({ submit: msg }),
+                      (msg) => setStatus({ success: true, message: msg }),
+                      () => {}
+                    )
+                  }
                   size="large"
                   variant="outlined"
                   sx={{

--- a/web/src/views/Log/component/TableRow.jsx
+++ b/web/src/views/Log/component/TableRow.jsx
@@ -323,13 +323,13 @@ function calculateTokens(item) {
     { key: 'reasoning_tokens', label: 'logPage.reasoningTokens', rate: reasoning_tokens, labelParams: { ratio: reasoning_tokens } },
     {
       key: 'input_image_tokens',
-      label: 'log.inputImageTokens',
+      label: 'logPage.inputImageTokens',
       rate: input_image_tokens,
       labelParams: { ratio: input_image_tokens }
     },
     {
       key: 'output_image_tokens',
-      label: 'log.outputImageTokens',
+      label: 'logPage.outputImageTokens',
       rate: output_image_tokens,
       labelParams: { ratio: output_image_tokens }
     }

--- a/web/src/views/Profile/index.jsx
+++ b/web/src/views/Profile/index.jsx
@@ -388,20 +388,20 @@ export default function Profile() {
                 )}
               </Grid>
             </SubCard>
-            <SubCard title="WebAuthn 凭据管理">
+            <SubCard title={t('profilePage.webauthnManagement')}>
               <Grid container spacing={2}>
                 <Grid xs={12}>
-                  <Alert severity="info">WebAuthn 提供无密码身份验证，您可以使用指纹、Face ID 或安全密钥等生物识别方式进行登录。</Alert>
+                  <Alert severity="info">{t('profilePage.webauthnDescription')}</Alert>
                 </Grid>
                 <Grid xs={12}>
                   <Button variant="contained" onClick={handleWebAuthnRegister} disabled={loadingWebAuthn}>
-                    注册 WebAuthn 凭据
+                    {t('profilePage.registerWebauthn')}
                   </Button>
                 </Grid>
                 {webAuthnCredentials.length > 0 && (
                   <Grid xs={12}>
                     <Typography variant="h4" sx={{ mb: 2 }}>
-                      已注册的凭据
+                      {t('profilePage.registeredCredentials')}
                     </Typography>
                     {webAuthnCredentials.map((credential) => (
                       <Card
@@ -416,13 +416,13 @@ export default function Profile() {
                       >
                         <Stack>
                           <Typography variant="body1">
-                            别名:{' '}
+                            {t('profilePage.alias')}:{' '}
                             {credential.alias && credential.alias.trim() !== ''
                               ? credential.alias
                               : new Date(credential.created_time * 1000).toLocaleString()}
                           </Typography>
                           <Typography variant="body2" color="text.secondary">
-                            凭据 ID:{' '}
+                            {t('profilePage.credentialId')}:{' '}
                             <span title={credential.credential_id}>
                               {credential.credential_id.length > 20
                                 ? credential.credential_id.substring(0, 20) + '...'
@@ -430,7 +430,7 @@ export default function Profile() {
                             </span>
                           </Typography>
                           <Typography variant="body2" color="text.secondary">
-                            注册时间: {new Date(credential.created_time * 1000).toLocaleString()}
+                            {t('profilePage.registerTime')}: {new Date(credential.created_time * 1000).toLocaleString()}
                           </Typography>
                         </Stack>
                         <Button
@@ -440,7 +440,7 @@ export default function Profile() {
                           onClick={() => handleDeleteWebAuthnCredential(credential.id)}
                           disabled={loadingWebAuthn}
                         >
-                          删除
+                          {t('profilePage.delete')}
                         </Button>
                       </Card>
                     ))}
@@ -448,7 +448,7 @@ export default function Profile() {
                 )}
                 {webAuthnCredentials.length === 0 && !loadingWebAuthn && (
                   <Grid xs={12}>
-                    <Alert severity="info">您还没有注册任何 WebAuthn 凭据。点击上方按钮开始注册。</Alert>
+                    <Alert severity="info">{t('profilePage.noWebauthnCredentials')}</Alert>
                   </Grid>
                 )}
               </Grid>


### PR DESCRIPTION
- 更新并统一WebAuthn模块中的多语言资源文本，包括注册、管理、凭据别名等字段。
- 替换多个组件中的硬编码文本，使用i18n模块提供的翻译方法`t()`。
- 提升多语言支持的维护性和一致性。

