### PR TITLE
feat(token): 增加令牌模型限制功能支持

### DIFF
--- a/model/token.go
+++ b/model/token.go
@@ -64,12 +64,18 @@ func (token *Token) AfterCreate(tx *gorm.DB) (err error) {
 }
 
 type TokenSetting struct {
-	Heartbeat HeartbeatSetting `json:"heartbeat,omitempty"`
+	Heartbeat HeartbeatSetting  `json:"heartbeat,omitempty"`
+	Limits    LimitModelSetting `json:"limits,omitempty"`
 }
 
 type HeartbeatSetting struct {
 	Enabled        bool `json:"enabled"`
 	TimeoutSeconds int  `json:"timeout_seconds"`
+}
+
+type LimitModelSetting struct {
+	Enabled bool     `json:"enabled"`
+	Models  []string `json:"models"`
 }
 
 func GetUserTokensList(userId int, params *GenericParams) (*DataResult[Token], error) {

--- a/web/src/views/Token/component/EditModal.jsx
+++ b/web/src/views/Token/component/EditModal.jsx
@@ -22,7 +22,10 @@ import {
   Select,
   MenuItem,
   Typography,
-  Grid
+  Grid,
+  Checkbox,
+  ListItemText,
+  Chip
 } from '@mui/material';
 
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -58,11 +61,15 @@ const originInputs = {
   expired_time: -1,
   unlimited_quota: false,
   group: '',
-
+  backup_group: '',
   setting: {
     heartbeat: {
       enabled: false,
       timeout_seconds: 30
+    },
+    limits: {
+      enabled: false,
+      models: undefined
     }
   }
 };
@@ -71,6 +78,52 @@ const EditModal = ({ open, tokenId, onCancel, onOk, userGroupOptions }) => {
   const { t } = useTranslation();
   const theme = useTheme();
   const [inputs, setInputs] = useState(originInputs);
+  const [modelOptions, setModelOptions] = useState([]);
+  const [ownedByIcons, setOwnedByIcons] = useState({}); // 新增状态存储提供商图标
+
+  // 获取模型提供商图标
+  const fetchOwnedByIcons = async () => {
+    try {
+      const res = await API.get('/api/model_ownedby/');
+      const { success, data } = res.data;
+      if (success) {
+        // 将提供商数据转换为以名称为键的对象
+        const iconMap = {};
+        data.forEach((provider) => {
+          iconMap[provider.name] = provider.icon || '/src/assets/images/icons/unknown_type.svg';
+        });
+        setOwnedByIcons(iconMap);
+      }
+    } catch (error) {
+      console.error('获取模型提供商图标失败:', error);
+    }
+  };
+
+  // 获取模型列表
+  const fetchModelOptions = async () => {
+    try {
+      const res = await API.get('/api/available_model');
+      const { success, data } = res.data;
+      if (success) {
+        // 将新的数据结构转换为模型选项数组
+        const models = Object.keys(data).map((modelId) => ({
+          id: modelId,
+          name: modelId,
+          owned_by: data[modelId].owned_by,
+          groups: data[modelId].groups,
+          price: data[modelId].price
+        }));
+        setModelOptions(models);
+      }
+    } catch (error) {
+      console.error('获取模型列表失败:', error);
+    }
+  };
+
+  // 获取模型图标的辅助函数
+  const getModelIcon = (ownedBy) => {
+    return ownedByIcons[ownedBy] || '/src/assets/images/icons/unknown_type.svg';
+  };
 
   const submit = async (values, { setErrors, setStatus, setSubmitting }) => {
     setSubmitting(true);
@@ -118,6 +171,13 @@ const EditModal = ({ open, tokenId, onCancel, onOk, userGroupOptions }) => {
       return;
     }
   };
+
+  useEffect(() => {
+    if (open) {
+      fetchOwnedByIcons(); // 先获取图标数据
+      fetchModelOptions();
+    }
+  }, [open]);
 
   useEffect(() => {
     if (tokenId) {
@@ -326,13 +386,9 @@ const EditModal = ({ open, tokenId, onCancel, onOk, userGroupOptions }) => {
                       }}
                       variant={'outlined'}
                     >
-                      <MenuItem value="-1">无备份分组</MenuItem>
+                      <MenuItem value="-1">无备用分组</MenuItem>
                       {userGroupOptions.map((option) => (
-                        <MenuItem 
-                          key={option.value} 
-                          value={option.value}
-                          disabled={values.group === option.value && values.group !== ''}
-                        >
+                        <MenuItem key={option.value} value={option.value} disabled={values.group === option.value && values.group !== ''}>
                           {option.label}
                         </MenuItem>
                       ))}
@@ -340,6 +396,113 @@ const EditModal = ({ open, tokenId, onCancel, onOk, userGroupOptions }) => {
                   </FormControl>
                 </Grid>
               </Grid>
+
+              {/*令牌限制设置*/}
+              <Divider sx={{ margin: '16px 0px' }} />
+              <Typography variant="h4">令牌限制</Typography>
+              <Typography variant="caption">设置后，可以对令牌进行限制</Typography>
+
+              {/*是否开启限制*/}
+              <FormControl fullWidth>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={values?.setting?.limits?.enabled === true}
+                      onClick={() => {
+                        setFieldValue('setting.limits.enabled', !values.setting?.limits?.enabled);
+                        // 如果关闭限制，清空已选择的模型
+                        if (values.setting?.limits?.enabled) {
+                          setFieldValue('setting.limits.models', []);
+                        }
+                      }}
+                    />
+                  }
+                  label="启用限制"
+                />
+              </FormControl>
+
+              {/*下拉框多选模型*/}
+              {values?.setting?.limits?.enabled && (
+                <FormControl fullWidth sx={{ ...theme.typography.otherInput }}>
+                  <InputLabel>模型限制</InputLabel>
+                  <Select
+                    variant="outlined"
+                    multiple
+                    value={values?.setting?.limits?.models || []}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setFieldValue('setting.limits.models', typeof value === 'string' ? value.split(',') : value);
+                    }}
+                    label="允许的模型列表"
+                    MenuProps={{
+                      anchorOrigin: {
+                        vertical: 'top',
+                        horizontal: 'left'
+                      },
+                      transformOrigin: {
+                        vertical: 'bottom',
+                        horizontal: 'left'
+                      },
+                      PaperProps: {
+                        style: {
+                          maxHeight: 300, // 限制下拉菜单最大高度
+                          overflow: 'auto', // 添加滚动条
+                          marginBottom: 8, // 添加一点间距
+                          boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.1)', // 美化阴影
+                          borderRadius: '8px' // 圆角
+                        }
+                      }
+                    }}
+                    renderValue={(selected) => (
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                        {selected.map((value) => {
+                          const model = modelOptions.find((m) => m.id === value);
+                          return (
+                            <Chip
+                              key={value}
+                              label={model ? model.name : value}
+                              size="small"
+                              variant="outlined"
+                              color="primary"
+                              style={{
+                                margin: 1,
+                                color: theme.palette.primary.main
+                              }}
+                            />
+                          );
+                        })}
+                      </div>
+                    )}
+                  >
+                    {modelOptions.map((model) => (
+                      <MenuItem key={model.id} value={model.id}>
+                        <ListItemText
+                          primary={
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                              <img
+                                src={getModelIcon(model.owned_by)}
+                                alt={model.owned_by}
+                                style={{ width: 20, height: 20, borderRadius: '4px' }}
+                                onError={(e) => {
+                                  e.target.src = '/src/assets/images/icons/unknown_type.svg';
+                                }}
+                              />
+                              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+                                <span style={{ fontWeight: 500 }}>{model.name}</span>
+                                <span style={{ fontSize: '0.75rem', color: theme.palette.text.secondary }}>
+                                  {model.owned_by} | {model.groups.join(', ')}
+                                </span>
+                              </div>
+                            </div>
+                          }
+                        />
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  <FormHelperText>选择允许此令牌使用的模型，未选择则表示允许所有模型</FormHelperText>
+                </FormControl>
+              )}
+
               <DialogActions>
                 <Button onClick={onCancel}>{t('token_index.cancel')}</Button>
                 <Button disableElevation disabled={isSubmitting} type="submit" variant="contained" color="primary">


### PR DESCRIPTION
- 引入`CheckLimitModel`函数，依据令牌配置动态限制可用模型。
- 新增令牌设置的限制选项及关联字段，支持模型选择与多选。
- 优化前端界面，加入模型限制开关、模型多选菜单及视觉提示。
- 完善后端模型限制校验，返回错误提示。

增强了令牌的灵活性与管控能力，提高了模型使用的安全性与可控性。

我已确认该 PR 已自测通过，相关截图如下：
<img width="695" height="514" alt="image" src="https://github.com/user-attachments/assets/ab754cab-c217-4c92-a385-9b86373b43aa" />
