### PR TITLE
feat(provider): 支持新版本Bedrock API密钥认证模式

### DIFF
--- a/web/src/views/Channel/type/Config.js
+++ b/web/src/views/Channel/type/Config.js
@@ -326,7 +326,7 @@ const typeConfig = {
       test_model: 'claude-3-haiku-20240307'
     },
     prompt: {
-      key: '按照如下格式输入：Region|AccessKeyID|SecretAccessKey|SessionToken 其中SessionToken可不填空'
+      key: '老版本Bedrock按照如下格式输入：Region|AccessKeyID|SecretAccessKey|SessionToken 其中SessionToken可不填空,新版本Bedrock按照如下格式输入：Region|Token(其中Token不能为空，Token前往新版本Bedrock控制台创建API密钥)'
     },
     modelGroup: 'Anthropic'
   },


### PR DESCRIPTION
- 更新Bedrock的配置说明，包括老版本和新版本的密钥格式规范。
- 在API请求中增加对新版本API密钥的支持，通过Authorization头传递。
- 优化密钥解析逻辑，补充对新格式密钥的处理，提升兼容性。

