### PR TITLE
feat(provider): 为Ollama提供商添加模型列表获取功能并支持Ollama Cloud

### DIFF
--- a/providers/ollama/base.go
+++ b/providers/ollama/base.go
@@ -2,12 +2,12 @@ package ollama
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"one-api/common/requester"
 	"one-api/model"
-	"one-api/types"
-
 	"one-api/providers/base"
+	"one-api/types"
 )
 
 type OllamaProviderFactory struct{}
@@ -31,9 +31,10 @@ func (f OllamaProviderFactory) Create(channel *model.Channel) base.ProviderInter
 
 func getOllamaConfig() base.ProviderConfig {
 	return base.ProviderConfig{
-		BaseURL:         "",
+		BaseURL:         "https://ollama.com",
 		ChatCompletions: "/api/chat",
 		Embeddings:      "/api/embed",
+		ModelList:       "/api/tags",
 	}
 }
 
@@ -63,6 +64,7 @@ func errorHandle(OllamaError *OllamaError) *types.OpenAIError {
 func (p *OllamaProvider) GetRequestHeaders() (headers map[string]string) {
 	headers = make(map[string]string)
 	p.CommonRequestHeaders(headers)
+	headers["Authorization"] = fmt.Sprintf("Bearer %s", p.Channel.Key)
 
 	otherHeaders := p.Channel.Plugin.Data()["headers"]
 

--- a/providers/ollama/model.go
+++ b/providers/ollama/model.go
@@ -1,0 +1,29 @@
+package ollama
+
+import (
+	"errors"
+	"net/http"
+)
+
+func (p *OllamaProvider) GetModelList() ([]string, error) {
+	fullRequestURL := p.GetFullRequestURL(p.Config.ModelList, "")
+	headers := p.GetRequestHeaders()
+
+	req, err := p.Requester.NewRequest(http.MethodGet, fullRequestURL, p.Requester.WithHeader(headers))
+	if err != nil {
+		return nil, errors.New("new_request_failed")
+	}
+
+	response := &ModelListResponse{}
+	_, errWithCode := p.Requester.SendRequest(req, response, false)
+	if errWithCode != nil {
+		return nil, errors.New(errWithCode.Message)
+	}
+
+	var modelList []string
+	for _, model := range response.Models {
+		modelList = append(modelList, model.Model)
+	}
+
+	return modelList, nil
+}

--- a/providers/ollama/type.go
+++ b/providers/ollama/type.go
@@ -44,10 +44,30 @@ type EmbeddingRequest struct {
 
 type EmbeddingResponse struct {
 	OllamaError
-	Model           string       `json:"model,omitempty"`
-	Embeddings      [][]float64  `json:"embeddings,omitempty"`
-	Embedding       []float64    `json:"embedding,omitempty"`
-	TotalDuration   int64        `json:"total_duration,omitempty"`
-	LoadDuration    int64        `json:"load_duration,omitempty"`
-	PromptEvalCount int          `json:"prompt_eval_count,omitempty"`
+	Model           string      `json:"model,omitempty"`
+	Embeddings      [][]float64 `json:"embeddings,omitempty"`
+	Embedding       []float64   `json:"embedding,omitempty"`
+	TotalDuration   int64       `json:"total_duration,omitempty"`
+	LoadDuration    int64       `json:"load_duration,omitempty"`
+	PromptEvalCount int         `json:"prompt_eval_count,omitempty"`
+}
+
+type ModelListResponse struct {
+	Models []ModelInfo `json:"models"`
+}
+type ModelInfo struct {
+	Name       string       `json:"name"`
+	Model      string       `json:"model"`
+	ModifiedAt time.Time    `json:"modified_at"`
+	Size       int64        `json:"size"`
+	Digest     string       `json:"digest"`
+	Details    ModelDetails `json:"details"`
+}
+type ModelDetails struct {
+	ParentModel       string    `json:"parent_model"`
+	Format            string    `json:"format"`
+	Family            string    `json:"family"`
+	Families          *[]string `json:"families"`
+	ParameterSize     string    `json:"parameter_size"`
+	QuantizationLevel string    `json:"quantization_level"`
 }

--- a/web/src/constants/ChannelConstants.js
+++ b/web/src/constants/ChannelConstants.js
@@ -186,7 +186,7 @@ export const CHANNEL_OPTIONS = {
     text: 'Ollama',
     value: 39,
     color: 'orange',
-    url: ''
+    url: 'https://ollama.com'
   },
   40: {
     key: 40,

--- a/web/src/views/Channel/type/Config.js
+++ b/web/src/views/Channel/type/Config.js
@@ -418,12 +418,26 @@ const typeConfig = {
     modelGroup: 'Coze'
   },
   39: {
+    inputLabel: {
+      provider_models_list: '从Ollama获取模型'
+    },
     input: {
-      models: ['phi3', 'llama3']
+      base_url: 'https://ollama.com',
+      models: [
+        'glm-4.6',
+        'kimi-k2:1t',
+        'qwen3-coder:480b',
+        'deepseek-v3.1:671b',
+        'gpt-oss:120b',
+        'gpt-oss:20b',
+        'qwen3-vl:235b',
+        'minimax-m2'
+      ]
     },
     prompt: {
-      base_url: '请输入你部署的Ollama地址，例如：http://127.0.0.1:11434，如果你使用了cloudflare Zero Trust，可以在下方插件填入授权信息',
-      key: '请随意填写'
+      base_url:
+        '请输入你部署的Ollama地址或者Ollama Cloud地址，例如：http://127.0.0.1:11434或者https://ollama.com，如果你使用了cloudflare Zero Trust，可以在下方Header配置填入授权信息',
+      key: '本地部署可以随便填，Ollama Cloud请填写API KEY，获取地址https://ollama.com/settings/keys'
     }
   },
   40: {


### PR DESCRIPTION
- 新增GetModelList方法，支持从Ollama API获取可用模型列表
- 添加ModelListResponse和ModelInfo结构体用于解析模型信息
- 更新Ollama配置，添加ModelList端点和默认BaseURL
- 修改前端配置，支持从Ollama获取模型列表并更新默认模型

close #837

