### PR TITLE
增加友好的渠道名和类型到metrics的标签中&&为bedrock中的claude模型支持prompt_cache&&为bedrock渠道增加合并自定义参数的功能，和openai渠道保持一致

### DIFF
--- a/common/config/constants.go
+++ b/common/config/constants.go
@@ -306,6 +306,63 @@ const (
 	ChannelTypeXAI             = 56
 )
 
+// ChannelType2Name 将渠道类型 ID 映射到名称
+var ChannelType2Name = map[int]string{
+	ChannelTypeUnknown:         "Unknown",
+	ChannelTypeOpenAI:          "OpenAI",
+	ChannelTypeAzure:           "Azure",
+	ChannelTypeCustom:          "Custom",
+	ChannelTypePaLM:            "PaLM",
+	ChannelTypeAnthropic:       "Anthropic",
+	ChannelTypeBaidu:           "Baidu",
+	ChannelTypeZhipu:           "Zhipu",
+	ChannelTypeAli:             "Ali",
+	ChannelTypeXunfei:          "Xunfei",
+	ChannelType360:             "360",
+	ChannelTypeOpenRouter:      "OpenRouter",
+	ChannelTypeTencent:         "Tencent",
+	ChannelTypeAzureSpeech:     "AzureSpeech",
+	ChannelTypeGemini:          "Gemini",
+	ChannelTypeBaichuan:        "Baichuan",
+	ChannelTypeMiniMax:         "MiniMax",
+	ChannelTypeDeepseek:        "Deepseek",
+	ChannelTypeMoonshot:        "Moonshot",
+	ChannelTypeMistral:         "Mistral",
+	ChannelTypeGroq:            "Groq",
+	ChannelTypeBedrock:         "Bedrock",
+	ChannelTypeLingyi:          "Lingyi",
+	ChannelTypeMidjourney:      "Midjourney",
+	ChannelTypeCloudflareAI:    "CloudflareAI",
+	ChannelTypeCohere:          "Cohere",
+	ChannelTypeStabilityAI:     "StabilityAI",
+	ChannelTypeCoze:            "Coze",
+	ChannelTypeOllama:          "Ollama",
+	ChannelTypeHunyuan:         "Hunyuan",
+	ChannelTypeSuno:            "Suno",
+	ChannelTypeVertexAI:        "VertexAI",
+	ChannelTypeLLAMA:           "LLAMA",
+	ChannelTypeIdeogram:        "Ideogram",
+	ChannelTypeSiliconflow:     "Siliconflow",
+	ChannelTypeFlux:            "Flux",
+	ChannelTypeJina:            "Jina",
+	ChannelTypeRerank:          "Rerank",
+	ChannelTypeGithub:          "Github",
+	ChannelTypeRecraft:         "Recraft",
+	ChannelTypeReplicate:       "Replicate",
+	ChannelTypeKling:           "Kling",
+	ChannelTypeAzureDatabricks: "AzureDatabricks",
+	ChannelTypeAzureV1:         "AzureV1",
+	ChannelTypeXAI:             "XAI",
+}
+
+// GetChannelTypeName 获取渠道类型名称
+func GetChannelTypeName(channelType int) string {
+	if name, ok := ChannelType2Name[channelType]; ok {
+		return name
+	}
+	return "Unknown"
+}
+
 const (
 	RelayModeUnknown = iota
 	RelayModeChatCompletions

--- a/metrics/main.go
+++ b/metrics/main.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"one-api/common/config"
 	"strconv"
 	"time"
 
@@ -40,7 +41,7 @@ func init() {
 			Name: "provider_requests_total",
 			Help: "Total number of provider requests.",
 		},
-		[]string{"channel_type", "channel_id", "model", "type"},
+		[]string{"channel_type_id", "channel_type", "channel_id", "channel_name", "model", "type"},
 	)
 
 	// 3. 监控 panic
@@ -83,11 +84,17 @@ func RecordProvider(c *gin.Context, statusCode int) {
 
 	channelType := c.GetInt("channel_type")
 	channelId := c.GetInt("channel_id")
+	channelName := c.GetString("channel_name")
+
+	// 将 channel type ID 转换为名称
+	channelTypeName := config.GetChannelTypeName(channelType)
 
 	go SafelyRecordMetric(func() {
 		providerCounter.WithLabelValues(
 			strconv.Itoa(channelType),
+			channelTypeName,
 			strconv.Itoa(channelId),
+			channelName,
 			model,
 			strconv.Itoa(statusCode),
 		).Inc()

--- a/providers/bedrock/base.go
+++ b/providers/bedrock/base.go
@@ -135,3 +135,62 @@ func (p *BedrockProvider) Sign(req *http.Request) error {
 
 	return nil
 }
+
+// mergeCustomParams 合并自定义参数到请求体中
+func (p *BedrockProvider) mergeCustomParams(requestMap map[string]interface{}, customParams map[string]interface{}) map[string]interface{} {
+	// 检查是否需要覆盖已有参数
+	shouldOverwrite := false
+	if overwriteValue, exists := customParams["overwrite"]; exists {
+		if boolValue, ok := overwriteValue.(bool); ok {
+			shouldOverwrite = boolValue
+		}
+	}
+
+	// 如果配置是pre_add，则此处跳过所有处理
+	if preAdd, exists := customParams["pre_add"]; exists && preAdd == true {
+		return requestMap
+	}
+
+	// 检查是否按照模型粒度控制
+	perModel := false
+	if perModelValue, exists := customParams["per_model"]; exists {
+		if boolValue, ok := perModelValue.(bool); ok {
+			perModel = boolValue
+		}
+	}
+
+	customParamsModel := customParams
+	if perModel {
+		if modelValue, ok := requestMap["model"].(string); ok {
+			if v, exists := customParams[modelValue]; exists {
+				if modelConfig, ok := v.(map[string]interface{}); ok {
+					customParamsModel = modelConfig
+				} else {
+					customParamsModel = map[string]interface{}{}
+				}
+			} else {
+				customParamsModel = map[string]interface{}{}
+			}
+		}
+	}
+
+	// 添加额外参数
+	for key, value := range customParamsModel {
+		// 忽略特殊键
+		if key == "stream" || key == "overwrite" || key == "per_model" || key == "pre_add" {
+			continue
+		}
+		// 根据覆盖设置决定如何添加参数
+		if shouldOverwrite {
+			// 覆盖模式：直接添加/覆盖参数
+			requestMap[key] = value
+		} else {
+			// 非覆盖模式：仅当参数不存在时添加
+			if _, exists := requestMap[key]; !exists {
+				requestMap[key] = value
+			}
+		}
+	}
+
+	return requestMap
+}

--- a/providers/claude/chat.go
+++ b/providers/claude/chat.go
@@ -478,11 +478,20 @@ func (h *ClaudeStreamHandler) HandlerStream(rawLine *[]byte, dataChan chan strin
 	case "message_start":
 		h.convertToOpenaiStream(&claudeResponse, dataChan)
 		h.Usage.PromptTokens = claudeResponse.Message.Usage.InputTokens
+		// 设置缓存信息
+		h.Usage.PromptTokensDetails.CachedWriteTokens = claudeResponse.Message.Usage.CacheCreationInputTokens
+		h.Usage.PromptTokensDetails.CachedReadTokens = claudeResponse.Message.Usage.CacheReadInputTokens
+		h.Usage.PromptTokensDetails.CachedTokens = claudeResponse.Message.Usage.CacheReadInputTokens
+		h.Usage.CacheCreationInputTokens = claudeResponse.Message.Usage.CacheCreationInputTokens
+		h.Usage.CacheReadInputTokens = claudeResponse.Message.Usage.CacheReadInputTokens
 
 	case "message_delta":
 		h.convertToOpenaiStream(&claudeResponse, dataChan)
 		h.Usage.CompletionTokens = claudeResponse.Usage.OutputTokens
 		h.Usage.TotalTokens = h.Usage.PromptTokens + h.Usage.CompletionTokens
+
+		// 发送包含 usage 信息的 chunk（类似 OpenAI 的 stream_options.include_usage 行为）
+		h.sendUsageChunk(dataChan)
 
 	case "content_block_delta":
 		h.convertToOpenaiStream(&claudeResponse, dataChan)
@@ -562,12 +571,50 @@ func (h *ClaudeStreamHandler) convertToOpenaiStream(claudeResponse *ClaudeStream
 	if finishReason != "" {
 		choice.FinishReason = &finishReason
 	}
+
 	chatCompletion := types.ChatCompletionStreamResponse{
 		ID:      fmt.Sprintf("chatcmpl-%s", utils.GetUUID()),
 		Object:  "chat.completion.chunk",
 		Created: utils.GetTimestamp(),
 		Model:   h.Request.Model,
 		Choices: []types.ChatCompletionStreamChoice{choice},
+	}
+
+	responseBody, _ := json.Marshal(chatCompletion)
+	dataChan <- string(responseBody)
+}
+
+// sendUsageChunk 发送包含 usage 信息的 chunk（类似 OpenAI 的 stream_options.include_usage 行为）
+// 这个 chunk 包含一个空 delta 的 choice 和 usage 信息
+func (h *ClaudeStreamHandler) sendUsageChunk(dataChan chan string) {
+	// 直接从 h.Usage 复制完整的 usage 信息（已经通过 ClaudeUsageToOpenaiUsage 转换过）
+	usageCopy := &types.Usage{
+		PromptTokens:             h.Usage.PromptTokens,
+		CompletionTokens:         h.Usage.CompletionTokens,
+		TotalTokens:              h.Usage.TotalTokens,
+		CacheCreationInputTokens: h.Usage.CacheCreationInputTokens,
+		CacheReadInputTokens:     h.Usage.CacheReadInputTokens,
+		PromptTokensDetails:      h.Usage.PromptTokensDetails,
+		CompletionTokensDetails:  h.Usage.CompletionTokensDetails,
+	}
+
+	// 创建一个空的 choice（模仿 OpenAI 的格式）
+	choice := types.ChatCompletionStreamChoice{
+		Index: 0,
+		Delta: types.ChatCompletionStreamChoiceDelta{
+			Role:    "",
+			Content: "",
+		},
+		FinishReason: nil,
+	}
+
+	chatCompletion := types.ChatCompletionStreamResponse{
+		ID:      fmt.Sprintf("chatcmpl-%s", utils.GetUUID()),
+		Object:  "chat.completion.chunk",
+		Created: utils.GetTimestamp(),
+		Model:   h.Request.Model,
+		Choices: []types.ChatCompletionStreamChoice{choice},
+		Usage:   usageCopy,
 	}
 
 	responseBody, _ := json.Marshal(chatCompletion)

--- a/providers/claude/common.go
+++ b/providers/claude/common.go
@@ -83,12 +83,21 @@ func ClaudeUsageToOpenaiUsage(cUsage *Usage, usage *types.Usage) bool {
 		return false
 	}
 
+	// 设置缓存信息到内部字段（用于内部统计）
 	usage.PromptTokensDetails.CachedWriteTokens = cUsage.CacheCreationInputTokens
 	usage.PromptTokensDetails.CachedReadTokens = cUsage.CacheReadInputTokens
+	usage.PromptTokensDetails.CachedTokens = cUsage.CacheReadInputTokens // cached_tokens 显示读取的缓存
 
-	usage.PromptTokens = cUsage.InputTokens + cUsage.CacheCreationInputTokens + cUsage.CacheReadInputTokens
+	// 设置缓存信息到顶层字段（用于 API 响应）
+	usage.CacheCreationInputTokens = cUsage.CacheCreationInputTokens
+	usage.CacheReadInputTokens = cUsage.CacheReadInputTokens
+
+	// 注意：根据 OpenAI 的格式，prompt_tokens 不包含缓存 tokens
+	// 缓存 tokens 单独在顶层字段中显示
+	usage.PromptTokens = cUsage.InputTokens
 	usage.CompletionTokens = cUsage.OutputTokens
-	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	// total_tokens 包含所有 tokens（包括缓存）
+	usage.TotalTokens = cUsage.InputTokens + cUsage.OutputTokens + cUsage.CacheCreationInputTokens + cUsage.CacheReadInputTokens
 
 	return true
 }

--- a/relay/common.go
+++ b/relay/common.go
@@ -113,6 +113,7 @@ func GetProvider(c *gin.Context, modelName string) (provider providersBase.Provi
 	}
 	c.Set("channel_id", channel.Id)
 	c.Set("channel_type", channel.Type)
+	c.Set("channel_name", channel.Name)
 
 	provider = providers.GetProvider(channel, c)
 	if provider == nil {

--- a/types/common.go
+++ b/types/common.go
@@ -14,6 +14,10 @@ type Usage struct {
 	PromptTokensDetails     PromptTokensDetails     `json:"prompt_tokens_details"`
 	CompletionTokensDetails CompletionTokensDetails `json:"completion_tokens_details"`
 
+	// Claude 缓存字段（顶层）- 始终显示，即使为 0
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+
 	ExtraTokens  map[string]int          `json:"-"`
 	ExtraBilling map[string]ExtraBilling `json:"-"`
 	TextBuilder  strings.Builder         `json:"-"`
@@ -94,7 +98,7 @@ func (u *Usage) SetExtraTokens(key string, value int) {
 
 type PromptTokensDetails struct {
 	AudioTokens          int `json:"audio_tokens,omitempty"`
-	CachedTokens         int `json:"cached_tokens,omitempty"`
+	CachedTokens         int `json:"cached_tokens"` // 移除 omitempty，始终显示
 	TextTokens           int `json:"text_tokens,omitempty"`
 	ImageTokens          int `json:"image_tokens,omitempty"`
 	CachedTokensInternal int `json:"cached_tokens_internal,omitempty"`


### PR DESCRIPTION
- 增加友好的渠道名和类型到metrics的标签中,这样grafana中就可以比较清晰的看到渠道名字了
- 为bedrock中的claude模型支持prompt_cache
- 为bedrock渠道增加合并自定义参数的功能，和openai渠道保持一致

我已确认该 PR 已自测通过，相关截图如下：
<img width="1598" height="108" alt="image" src="https://github.com/user-attachments/assets/83666f84-4744-4c08-8ce9-35238f48236d" />

