### PR TITLE
refactor(model): 为价格信息添加模型详情支持

### DIFF
--- a/model/model_info.go
+++ b/model/model_info.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"one-api/common/logger"
+	"one-api/common/utils"
 )
 
 type ModelInfo struct {
@@ -17,6 +18,48 @@ type ModelInfo struct {
 	SupportUrl       string `json:"support_url" gorm:"type:text"`
 	CreatedAt        int64  `json:"created_at" gorm:"autoCreateTime"`
 	UpdatedAt        int64  `json:"updated_at" gorm:"autoUpdateTime"`
+}
+
+type ModelInfoResponse struct {
+	Model            string   `json:"model"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	ContextLength    int      `json:"context_length"`
+	MaxTokens        int      `json:"max_tokens"`
+	InputModalities  []string `json:"input_modalities"`
+	OutputModalities []string `json:"output_modalities"`
+	Tags             []string `json:"tags"`
+	SupportUrl       []string `json:"support_url"`
+	CreatedAt        int64    `json:"created_at"`
+	UpdatedAt        int64    `json:"updated_at"`
+}
+
+func (m *ModelInfo) ToResponse() *ModelInfoResponse {
+	res := &ModelInfoResponse{
+		Model:         m.Model,
+		Name:          m.Name,
+		Description:   m.Description,
+		ContextLength: m.ContextLength,
+		MaxTokens:     m.MaxTokens,
+		CreatedAt:     m.CreatedAt,
+		UpdatedAt:     m.UpdatedAt,
+	}
+
+	res.InputModalities, _ = utils.UnmarshalString[[]string](m.InputModalities)
+	res.OutputModalities, _ = utils.UnmarshalString[[]string](m.OutputModalities)
+	res.Tags, _ = utils.UnmarshalString[[]string](m.Tags)
+
+	var err error
+	res.SupportUrl, err = utils.UnmarshalString[[]string](m.SupportUrl)
+	if err != nil {
+		if m.SupportUrl != "" {
+			res.SupportUrl = []string{m.SupportUrl}
+		} else {
+			res.SupportUrl = []string{}
+		}
+	}
+
+	return res
 }
 
 func (m *ModelInfo) TableName() string {

--- a/model/price.go
+++ b/model/price.go
@@ -62,6 +62,7 @@ type Price struct {
 	Locked      bool    `json:"locked" gorm:"default:false"` // 如果模型为locked 则覆盖模式不会更新locked的模型价格
 
 	ExtraRatios *datatypes.JSONType[map[string]float64] `json:"extra_ratios,omitempty" gorm:"type:json"`
+	ModelInfo   *ModelInfoResponse                      `json:"model_info,omitempty" gorm:"-"`
 }
 
 func GetAllPrices() ([]*Price, error) {

--- a/model/pricing.go
+++ b/model/pricing.go
@@ -77,6 +77,22 @@ func (p *Pricing) Init() error {
 		return nil
 	}
 
+	modelInfos, err := GetAllModelInfo()
+	if err == nil {
+		modelInfoMap := make(map[string]*ModelInfoResponse)
+		for _, info := range modelInfos {
+			modelInfoMap[info.Model] = info.ToResponse()
+		}
+
+		for _, price := range prices {
+			if info, ok := modelInfoMap[price.Model]; ok {
+				price.ModelInfo = info
+			}
+		}
+	} else {
+		logger.SysError("Failed to fetch model infos: " + err.Error())
+	}
+
 	newPrices := make(map[string]*Price)
 	newMatch := make(map[string]bool)
 


### PR DESCRIPTION
* 在ModelInfo中添加ToResponse方法，将模型信息转换为API响应格式
* 为Price结构体新增ModelInfo字段，用于存储关联的模型详细信息
* 在GetAllPrices中集成模型信息获取逻辑，增强价格数据的完整性
* 支持显示模型的模态类型、标签、上下文长度等关键参数

