### PR TITLE
fix(model): 修复导入模态框默认模态类型设置

### DIFF
--- a/web/src/views/ModelInfo/component/ImportModal.jsx
+++ b/web/src/views/ModelInfo/component/ImportModal.jsx
@@ -70,8 +70,8 @@ const ImportModal = ({ open, onCancel, onOk, existingModels = [] }) => {
             description: modelInfo.description || '',
             context_length: modelInfo.context_length || 0, // 默认值
             max_tokens: modelInfo.max_tokens || 0,
-            input_modalities: JSON.stringify(modelInfo.input_modalities || ['text']),
-            output_modalities: JSON.stringify(modelInfo.output_modalities || ['text']),
+            input_modalities: JSON.stringify(modelInfo.input_modalities || []),
+            output_modalities: JSON.stringify(modelInfo.output_modalities || []),
             tags: JSON.stringify(modelInfo.tags || []),
             isConflict: existingModels.includes(modelInfo.model || item.model)
           };


### PR DESCRIPTION
- 将输入模态类型默认值从 ['text'] 修改为空数组 []
- 将输出模态类型默认值从 ['text'] 修改为空数组 []
- 确保导入模型时模态类型字段使用正确的默认空值
