### PR TITLE
feat(settings): 添加网站统计代码配置功能

### DIFF
--- a/common/config/constants.go
+++ b/common/config/constants.go
@@ -22,6 +22,7 @@ var Logo = ""
 var TopUpLink = ""
 var ChatLink = ""
 var ChatLinks = ""
+var AnalyticsCode = ""
 var QuotaPerUnit = 500 * 1000.0 // $0.002 / 1K tokens
 var DisplayInCurrencyEnabled = true
 

--- a/controller/misc.go
+++ b/controller/misc.go
@@ -35,6 +35,7 @@ func GetStatus(c *gin.Context) {
 			"logo":                config.Logo,
 			"language":            config.Language,
 			"footer_html":         config.Footer,
+			"analytics_code":      config.AnalyticsCode,
 			"wechat_qrcode":       config.WeChatAccountQRCodeImageURL,
 			"wechat_login":        config.WeChatAuthEnabled,
 			"server_address":      config.ServerAddress,

--- a/model/option.go
+++ b/model/option.go
@@ -61,6 +61,7 @@ func InitOptionMap() {
 	config.GlobalOption.RegisterString("Footer", &config.Footer)
 	config.GlobalOption.RegisterString("SystemName", &config.SystemName)
 	config.GlobalOption.RegisterString("Logo", &config.Logo)
+	config.GlobalOption.RegisterString("AnalyticsCode", &config.AnalyticsCode)
 	config.GlobalOption.RegisterString("ServerAddress", &config.ServerAddress)
 	config.GlobalOption.RegisterString("GitHubClientId", &config.GitHubClientId)
 	config.GlobalOption.RegisterString("GitHubClientSecret", &config.GitHubClientSecret)

--- a/web/src/config.js
+++ b/web/src/config.js
@@ -14,6 +14,7 @@ const config = {
     display_in_currency: true,
     email_verification: false,
     footer_html: '',
+    analytics_code: '',
     github_client_id: '',
     github_oauth: false,
     oidc_auth: false,

--- a/web/src/contexts/StatusContext.jsx
+++ b/web/src/contexts/StatusContext.jsx
@@ -15,6 +15,7 @@ const StatusProvider = ({ children }) => {
 
   const loadStatus = useCallback(async () => {
     let system_name = '';
+    let analytics_code = '';
     try {
       const res = await API.get('/api/status');
       const { success, data } = res.data;
@@ -41,6 +42,9 @@ const StatusProvider = ({ children }) => {
         if (data.system_name) {
           system_name = data.system_name;
         }
+        if (data.analytics_code) {
+          analytics_code = data.analytics_code;
+        }
       } else {
         const backupSiteInfo = localStorage.getItem('siteInfo');
         if (backupSiteInfo) {
@@ -60,6 +64,19 @@ const StatusProvider = ({ children }) => {
 
     if (system_name) {
       document.title = system_name;
+    }
+
+    if (analytics_code) {
+      // Check if the script is already injected
+      if (!document.getElementById('analytics-code')) {
+        const range = document.createRange();
+        const fragment = range.createContextualFragment(analytics_code);
+        // Add an ID to the first child to prevent duplicate injection
+        if (fragment.firstElementChild) {
+          fragment.firstElementChild.id = 'analytics-code';
+          document.head.appendChild(fragment);
+        }
+      }
     }
     // eslint-disable-next-line
   }, [dispatch]);

--- a/web/src/views/Setting/component/OtherSetting.jsx
+++ b/web/src/views/Setting/component/OtherSetting.jsx
@@ -30,7 +30,8 @@ const OtherSetting = () => {
     About: '',
     SystemName: '',
     Logo: '',
-    HomePageContent: ''
+    HomePageContent: '',
+    AnalyticsCode: ''
   });
   let [loading, setLoading] = useState(false);
   const [showUpdateModal, setShowUpdateModal] = useState(false);
@@ -109,6 +110,10 @@ const OtherSetting = () => {
 
   const submitAbout = async () => {
     await updateOption('About', inputs.About);
+  };
+
+  const submitAnalyticsCode = async () => {
+    await updateOption('AnalyticsCode', inputs.AnalyticsCode);
   };
 
   const submitOption = async (key) => {
@@ -294,6 +299,26 @@ const OtherSetting = () => {
             <Grid xs={12}>
               <Button variant="contained" onClick={submitFooter}>
                 {t('setting_index.otherSettings.customSettings.setFooter')}
+              </Button>
+            </Grid>
+            <Grid xs={12}>
+              <FormControl fullWidth>
+                <TextField
+                  multiline
+                  maxRows={15}
+                  id="AnalyticsCode"
+                  label="统计代码"
+                  value={inputs.AnalyticsCode}
+                  name="AnalyticsCode"
+                  onChange={handleInputChange}
+                  minRows={10}
+                  placeholder="在此输入统计代码，例如 Google Analytics 或 Umami"
+                />
+              </FormControl>
+            </Grid>
+            <Grid xs={12}>
+              <Button variant="contained" onClick={submitAnalyticsCode}>
+                保存统计代码
               </Button>
             </Grid>
           </Grid>


### PR DESCRIPTION
- 在设置页面新增统计代码输入框，支持 Google Analytics 等
- 实现统计代码动态注入到页面头部，避免重复加载
- 后端添加 AnalyticsCode 配置项和 API 接口支持
- 前端 StatusContext 处理统计代码的加载和应用

