### PR TITLE
chore(ci): 将Windows构建流程中的npm替换为yarn

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -26,8 +26,8 @@ jobs:
           CI: ""
         run: |
           cd web
-          npm install
-          VITE_APP_VERSION=$(git describe --tags) npm run build
+          yarn install
+          VITE_APP_VERSION=$(git describe --tags) yarn run build
           cd ..
       - name: Set up Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
- 在GitHub Actions的windows-release.yml中更新包管理器
- 使用yarn install替代npm install进行依赖安装
- 使用yarn run build替代npm run build执行构建
- 统一构建工具链使用yarn包管理器

