### PR TITLE
feat(channel): 自定义渠道添加Responses地址配置选项

### DIFF
--- a/web/src/views/Channel/type/Plugin.json
+++ b/web/src/views/Channel/type/Plugin.json
@@ -307,6 +307,12 @@
           "description": "默认为： /v1/audio/translations",
           "type": "string",
           "required": false
+        },
+        "12": {
+          "name": "Responses地址",
+          "description": "默认为： /v1/responses",
+          "type": "string",
+          "required": false
         }
       }
     }


### PR DESCRIPTION
- 默认值设置为 /v1/responses


close: #875

