### PR TITLE
feat: 增加Thinking思考开关支持

### DIFF
--- a/types/chat.go
+++ b/types/chat.go
@@ -217,6 +217,8 @@ type ChatCompletionRequest struct {
 	ThinkingBudget *int  `json:"thinking_budget,omitempty"` // qwen3 思考长度，只有enable_thinking开启才生效
 	EnableSearch   *bool `json:"enable_search,omitempty"`   // qwen 搜索开关
 
+  Thinking *interface{} `json:"thinking,omitempty"` // thinking 思考开关，兼容火山引擎
+  
 	OneOtherArg string `json:"-"`
 }
 


### PR DESCRIPTION
考虑到火山引擎的thinking参数需要被支持，用于自定义模型可以直接使用思考，额外参数配置方式如下：

```
{
  "pre_add": true,
  "per_model": true,
  "overwrite": true,
  "deepseek-v3.2-thinking": {
    "thinking": {
      "type": "enabled"
    }
  }
}
```
其中`deepseek-v3.2-thinking`和`deepseek-v3.2`设置为映射关系，当使用`deepseek-v3.2-thinking`时会使用思考

close #876