### PR TITLE
多机部署子节点没有定时同步新增的分组

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,6 +160,7 @@ func SyncChannelCache(frequency int) {
 		time.Sleep(time.Duration(frequency) * time.Second)
 		logger.SysLog("syncing channels from database")
 		model.ChannelGroup.Load()
+		model.GlobalUserGroupRatio.Load()
 		model.PricingInstance.Init()
 		model.ModelOwnedBysInstance.Load()
 	}


### PR DESCRIPTION
目前多机部署情况下，新增分组子节点读取不到，必须重启，看起来是漏掉了分组的同步