### PR TITLE
修复gemini警告

### DIFF
--- a/providers/gemini/type.go
+++ b/providers/gemini/type.go
@@ -359,12 +359,12 @@ func (e *GeminiErrorResponse) Error() string {
 }
 
 type GeminiChatResponse struct {
-	Candidates     []GeminiChatCandidate    `json:"candidates"`
-	PromptFeedback GeminiChatPromptFeedback `json:"promptFeedback"`
-	UsageMetadata  *GeminiUsageMetadata     `json:"usageMetadata,omitempty"`
-	ModelVersion   string                   `json:"modelVersion,omitempty"`
-	Model          string                   `json:"model,omitempty"`
-	ResponseId     string                   `json:"responseId,omitempty"`
+	Candidates     []GeminiChatCandidate     `json:"candidates"`
+	PromptFeedback *GeminiChatPromptFeedback `json:"promptFeedback,omitempty"`
+	UsageMetadata  *GeminiUsageMetadata      `json:"usageMetadata,omitempty"`
+	ModelVersion   string                    `json:"modelVersion,omitempty"`
+	Model          string                    `json:"model,omitempty"`
+	ResponseId     string                    `json:"responseId,omitempty"`
 	GeminiErrorResponse
 }
 


### PR DESCRIPTION
修复一个警告

  问题原因：

  1. 当 Go 解析 Google API 的响应时，由于 PromptFeedback 不是指针且没有 omitempty 标签，即使 API 响应中没有这个字段，Go 也会将其解析为零值（空字符串 ""）
  2. 当项目将响应转发给客户端时，json.Marshal 会将整个 PromptFeedback 对象序列化到 JSON 中，包括空字符串的 blockReason
  3. 如果客户端使用的是 Python 的 google-genai SDK，SDK 会验证 blockReason 是否是有效的枚举值，收到空字符串时会发出警告：
  UserWarning:  is not a valid BlockedReason

<img width="964" height="77" alt="image" src="https://github.com/user-attachments/assets/9341d429-fdaa-4aff-a401-2e73d2b8f889" />


我已确认该 PR 已自测通过，相关截图如下：

<img width="1105" height="745" alt="image" src="https://github.com/user-attachments/assets/375fd951-b18a-42f3-888c-740e91e7b426" />
