### PR TITLE
deepseek强制reasoning_content

### DIFF
--- a/web/src/views/Channel/type/Config.js
+++ b/web/src/views/Channel/type/Config.js
@@ -61,7 +61,12 @@ const defaultConfig = {
     pre_cost:
       '这里选择预计费选项，用于预估费用，如果你觉得计算图片占用太多资源，可以选择关闭图片计费。但是请注意：有些渠道在stream下是不会返回tokens的，这会导致输入tokens计算错误。',
     disabled_stream: '这里填写禁用流式的模型，注意：如果填写了禁用流式的模型，那么这些模型在流式请求时会跳过该渠道',
+<<<<<<< HEAD
     compatible_response: '兼容Response API'
+=======
+    compatible_response: '兼容Response API',
+    allow_extra_body: '开启后，将会透传用户请求中的额外字段（如OpenAI SDK的extra_body参数），适用于需要传递自定义参数到上游API的场景（只对OpenAI兼容渠道有效，claude, gemini不影响）'
+>>>>>>> 2f3c6fed (保持reasoning_content传递)
   },
   modelGroup: 'OpenAI'
 };

--- a/web/src/views/Channel/type/Config.js
+++ b/web/src/views/Channel/type/Config.js
@@ -61,12 +61,7 @@ const defaultConfig = {
     pre_cost:
       '这里选择预计费选项，用于预估费用，如果你觉得计算图片占用太多资源，可以选择关闭图片计费。但是请注意：有些渠道在stream下是不会返回tokens的，这会导致输入tokens计算错误。',
     disabled_stream: '这里填写禁用流式的模型，注意：如果填写了禁用流式的模型，那么这些模型在流式请求时会跳过该渠道',
-<<<<<<< HEAD
     compatible_response: '兼容Response API'
-=======
-    compatible_response: '兼容Response API',
-    allow_extra_body: '开启后，将会透传用户请求中的额外字段（如OpenAI SDK的extra_body参数），适用于需要传递自定义参数到上游API的场景（只对OpenAI兼容渠道有效，claude, gemini不影响）'
->>>>>>> 2f3c6fed (保持reasoning_content传递)
   },
   modelGroup: 'OpenAI'
 };


### PR DESCRIPTION
对于deepseek25年12月新版本的破坏性改动，

> 兼容性提示
> 因思考模式下的工具调用过程中要求用户回传 reasoning_content 给 API，若您的代码中未正确回传 reasoning_content，API 会返回 400 报错。正确回传方法请您参考下面的样例代码。

如果是思考模型必须要带上 reasoning_content，即便为空。如果是模型来回切换的情况，很容易就没有，所以在这里做一个兼容

我已确认该 PR 已自测通过

