### PR TITLE
当 MaxTokens >= 0 时设置 Gemini 模型的 ThinkingBudget 参数

### DIFF
--- a/providers/gemini/chat.go
+++ b/providers/gemini/chat.go
@@ -174,8 +174,8 @@ func ConvertFromChatOpenai(request *types.ChatCompletionRequest) (*GeminiChatReq
 	if request.Reasoning != nil {
 		thinkingConfig := &ThinkingConfig{}
 		
-		// Only set ThinkingBudget when MaxTokens > 0
-		if request.Reasoning.MaxTokens > 0 {
+		// Set ThinkingBudget when MaxTokens >= 0
+		if request.Reasoning.MaxTokens >= 0 {
 			thinkingConfig.ThinkingBudget = &request.Reasoning.MaxTokens
 		}
 		


### PR DESCRIPTION
当 MaxTokens >= 0 时设置 Gemini 模型的 ThinkingBudget 参数。

在 Gemini 2.5 Flash 模型中，ThinkingBudget = 0 代表关闭思考，如不设置 0 值，模型默认行为是进行思考而不是不思考。
因此，在 Gemini 2.5 Flash 模型中，ThinkingBudget = 0 是一个有效参数，不应被舍弃。