### PR TITLE
fix: 修复 Responses API cached_tokens 字段缺失问题

### DIFF
--- a/types/responses.go
+++ b/types/responses.go
@@ -648,7 +648,7 @@ type ResponsesUsageOutputTokensDetails struct {
 }
 
 type ResponsesUsageInputTokensDetails struct {
-	CachedTokens int `json:"cached_tokens,omitempty"`
+	CachedTokens int `json:"cached_tokens"`
 	TextTokens   int `json:"text_tokens,omitempty"`
 	ImageTokens  int `json:"image_tokens,omitempty"`
 }


### PR DESCRIPTION
问题：Codex CLI 等客户端在解析 response.completed 事件时，当 input_tokens_details 对象存在时，强制要求 cached_tokens 字段存在。 原代码使用 omitempty 标签导致零值时字段被省略，造成客户端解析失败并触发重试，最终报错 "missing field 'cached_tokens'"。

修复：移除 ResponsesUsageInputTokensDetails.CachedTokens 的 omitempty 标签， 确保即使值为 0 也会被序列化输出。

https://github.com/MartialBE/one-hub/issues/868

### 额外信息
已确定只在 Responses SSE 下触发该问题，并且 Codex CLI 在请求 Responses 端点时已硬编码 stream: true 强制获取流式响应。
相关代码部分如下
https://github.com/openai/codex/blob/3fc487e0e0788045460df1abe21dc9de47f3b7f9/codex-rs/codex-api/src/requests/responses.rs#L127-L140

自测通过，在codex里可以正常使用Response接口：
![PixPin_2026-01-25_09-49-09](https://github.com/user-attachments/assets/549a1bb0-1e3e-4b48-b923-5731a82b48f1)

转自：https://github.com/deanxv/done-hub/pull/39
