### PR TITLE
增加claude的count_token路由,在分布式部署下支持claude code

### DIFF
--- a/common/requester/http_requester.go
+++ b/common/requester/http_requester.go
@@ -240,8 +240,9 @@ func SetEventStreamHeaders(c *gin.Context) {
 	c.Writer.Header().Set("Content-Type", "text/event-stream")
 	c.Writer.Header().Set("Cache-Control", "no-cache")
 	c.Writer.Header().Set("Connection", "keep-alive")
-	c.Writer.Header().Set("Transfer-Encoding", "chunked")
 	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.WriteHeader(http.StatusOK)
+	c.Writer.Flush()
 }
 
 func GetJsonHeaders() map[string]string {

--- a/relay/claude.go
+++ b/relay/claude.go
@@ -142,6 +142,16 @@ func (r *relayClaudeOnly) HandleStreamError(err *types.OpenAIErrorWithStatusCode
 	r.c.Writer.Flush()
 }
 
+func ClaudeCountTokens(c *gin.Context) {
+	var req claude.ClaudeRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusOK, gin.H{"input_tokens": 0})
+		return
+	}
+	count, _ := CountTokenMessages(&req, 0)
+	c.JSON(http.StatusOK, gin.H{"input_tokens": count})
+}
+
 func CountTokenMessages(request *claude.ClaudeRequest, preCostType int) (int, error) {
 	if preCostType == config.PreContNotAll {
 		return 0, nil

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -110,6 +110,7 @@ func setSunoRouter(router *gin.Engine) {
 func setClaudeRouter(router *gin.Engine) {
 	relayClaudeRouter := router.Group("/claude")
 	relayV1Router := relayClaudeRouter.Group("/v1")
+	relayV1Router.POST("/messages/count_tokens", relay.ClaudeCountTokens)
 	relayV1Router.Use(middleware.APIEnabled("claude"), middleware.RelayCluadePanicRecover(), middleware.ClaudeAuth(), middleware.Distribute(), middleware.DynamicRedisRateLimiter())
 	{
 		relayV1Router.POST("/messages", relay.Relay)


### PR DESCRIPTION
claude code正式请求之前要请求count_token计算一下input token,似乎还没办法通过 CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 关闭,所以做一个简易版的 count_token 接口

这个问题对于分布式部署的时候会很严重,因为会重定向回master, post降级为get,直接报错, 造成claude code 无限等待

我已确认该 PR 已自测通过