### PR TITLE
Fix Vertex AI publisher selection for Claude

### DIFF
--- a/providers/vertexai/base.go
+++ b/providers/vertexai/base.go
@@ -184,8 +184,8 @@ func errorHandle(vertexaiError *VertexaiError) *types.OpenAIError {
 	}
 
 	return &types.OpenAIError{
-		Message: "VertexAI错误",
-		Type:    "gemini_error",
+		Message: vertexaiError.Error.Message,
+		Type:    "vertexai_error",
 		Param:   vertexaiError.Error.Status,
 		Code:    vertexaiError.Error.Code,
 	}

--- a/providers/vertexai/base.go
+++ b/providers/vertexai/base.go
@@ -59,7 +59,7 @@ type VertexAIProvider struct {
 
 func getConfig() base.ProviderConfig {
 	return base.ProviderConfig{
-		BaseURL:           "https://%saiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:%s",
+		BaseURL:           "https://%saiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/%s/models/%s:%s",
 		ChatCompletions:   "/",
 		ImagesGenerations: "/predict",
 	}
@@ -76,10 +76,14 @@ func getKeyConfig(vertexAI *VertexAIProvider) {
 }
 
 func (p *VertexAIProvider) GetFullRequestURL(modelName string, other string) string {
-	if p.Region == "global" {
-		return fmt.Sprintf(p.GetBaseURL(), "", p.ProjectID, p.Region, modelName, other)
+	publisher := "google"
+	if p.Category != nil && p.Category.Publisher != "" {
+		publisher = p.Category.Publisher
 	}
-	return fmt.Sprintf(p.GetBaseURL(), p.Region+"-", p.ProjectID, p.Region, modelName, other)
+	if p.Region == "global" {
+		return fmt.Sprintf(p.GetBaseURL(), "", p.ProjectID, p.Region, publisher, modelName, other)
+	}
+	return fmt.Sprintf(p.GetBaseURL(), p.Region+"-", p.ProjectID, p.Region, publisher, modelName, other)
 }
 
 func (p *VertexAIProvider) GetRequestHeaders() (headers map[string]string) {

--- a/providers/vertexai/base_test.go
+++ b/providers/vertexai/base_test.go
@@ -1,6 +1,8 @@
 package vertexai
 
 import (
+	"net/http"
+	"strings"
 	"testing"
 
 	"one-api/model"
@@ -44,4 +46,33 @@ func TestGetFullRequestURLUsesGooglePublisherForGemini(t *testing.T) {
 	if url != want {
 		t.Fatalf("unexpected url:\nwant: %s\ngot:  %s", want, url)
 	}
+}
+
+func TestRequestErrorHandlePreservesUpstreamMessage(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     make(http.Header),
+		Body:       ioNopCloser("{\"error\":{\"code\":400,\"message\":\"Publisher Model `publishers/anthropic/models/claude-sonnet-4-6` not found.\",\"status\":\"NOT_FOUND\"}}"),
+	}
+
+	openAIErr := RequestErrorHandle(nil)(resp)
+	if openAIErr == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(openAIErr.Message, "publishers/anthropic/models/claude-sonnet-4-6") {
+		t.Fatalf("expected upstream message to be preserved, got %q", openAIErr.Message)
+	}
+}
+
+func ioNopCloser(body string) *stringReadCloser {
+	return &stringReadCloser{Reader: strings.NewReader(body)}
+}
+
+type stringReadCloser struct {
+	*strings.Reader
+}
+
+func (r *stringReadCloser) Close() error {
+	return nil
 }

--- a/providers/vertexai/base_test.go
+++ b/providers/vertexai/base_test.go
@@ -1,0 +1,47 @@
+package vertexai
+
+import (
+	"testing"
+
+	"one-api/model"
+	"one-api/providers/base"
+	"one-api/providers/vertexai/category"
+)
+
+func TestGetFullRequestURLUsesAnthropicPublisherForClaude(t *testing.T) {
+	provider := &VertexAIProvider{
+		BaseProvider: base.BaseProvider{
+			Config:  getConfig(),
+			Channel: &model.Channel{},
+		},
+		Region:    "global",
+		ProjectID: "opx-platform",
+		Category:  &category.Category{Publisher: "anthropic"},
+	}
+
+	url := provider.GetFullRequestURL("claude-sonnet-4-6", "rawPredict")
+
+	want := "https://aiplatform.googleapis.com/v1/projects/opx-platform/locations/global/publishers/anthropic/models/claude-sonnet-4-6:rawPredict"
+	if url != want {
+		t.Fatalf("unexpected url:\nwant: %s\ngot:  %s", want, url)
+	}
+}
+
+func TestGetFullRequestURLUsesGooglePublisherForGemini(t *testing.T) {
+	provider := &VertexAIProvider{
+		BaseProvider: base.BaseProvider{
+			Config:  getConfig(),
+			Channel: &model.Channel{},
+		},
+		Region:    "us-central1",
+		ProjectID: "opx-platform",
+		Category:  &category.Category{Publisher: "google"},
+	}
+
+	url := provider.GetFullRequestURL("gemini-2.5-pro", "generateContent")
+
+	want := "https://us-central1-aiplatform.googleapis.com/v1/projects/opx-platform/locations/us-central1/publishers/google/models/gemini-2.5-pro:generateContent"
+	if url != want {
+		t.Fatalf("unexpected url:\nwant: %s\ngot:  %s", want, url)
+	}
+}

--- a/providers/vertexai/category/base.go
+++ b/providers/vertexai/category/base.go
@@ -11,6 +11,7 @@ import (
 
 type Category struct {
 	Category                  string
+	Publisher                 string
 	ChatComplete              ChatCompletionConvert
 	ResponseChatComplete      ChatCompletionResponse
 	ResponseChatCompleteStrem ChatCompletionStreamResponse

--- a/providers/vertexai/category/claude.go
+++ b/providers/vertexai/category/claude.go
@@ -33,6 +33,7 @@ var claudeMap = map[string]string{
 func init() {
 	CategoryMap["claude"] = &Category{
 		Category:                  "claude",
+		Publisher:                 "anthropic",
 		ChatComplete:              ConvertClaudeFromChatOpenai,
 		ResponseChatComplete:      ConvertClaudeToChatOpenai,
 		ResponseChatCompleteStrem: ClaudeChatCompleteStrem,

--- a/providers/vertexai/category/gemini.go
+++ b/providers/vertexai/category/gemini.go
@@ -13,6 +13,7 @@ import (
 func init() {
 	CategoryMap["gemini"] = &Category{
 		Category:                  "gemini",
+		Publisher:                 "google",
 		ChatComplete:              ConvertGeminiFromChatOpenai,
 		ResponseChatComplete:      ConvertGeminiToChatOpenai,
 		ResponseChatCompleteStrem: GeminiChatCompleteStrem,


### PR DESCRIPTION
Vertex AI 渠道已经调通了 Gemini 模型，但是 claude-sonne-4-6 (已经在 Vertex AI 上开通) 测速报错：
错误：测速失败，原因：Provider API error: VertexAI错误

One-Hub 后端日志只有：
ai-gateway  | 2026/04/01 - 20:14:06     INFO    middleware/logger.go:67 GIN request     {"status": 200, "request_id": "20260401201406290608562kY5A0byA", "method": "GET", "path": "/api/channel/test/1", "query": "model=claude-sonnet-4-6", "ip": "35.75.183.2", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36", "latency": "65.526124ms", "user_id": 1, "original_model": "", "new_model": "", "token_id": 0, "token_name": "", "channel_id": 0}

原因：VertexAI Claude URL 拼错了。仓库里 base.go (line 60) 把所有 VertexAI 模型都写死成了 publishers/google/models/...，而 Claude 官方要求的是 publishers/anthropic/models/...。所以即使你填对 claude-sonnet-4-6，当前代码大概率还是会报错。也就是说：

model 填 claude-sonnet-4-6
但代码还需要修成 Claude 走 anthropic publisher，Gemini 才走 google publisher
如果你要，我可以直接帮你把这段 VertexAI Claude 兼容补上。原因是 Google 官方文档里 Claude on Vertex AI 的 REST 路径模板是：

.../publishers/anthropic/models/MODEL:rawPredict