### PR TITLE
Add system prompt prepend and append functionality

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -42,6 +42,9 @@ type Channel struct {
 	CompatibleResponse bool    `json:"compatible_response" gorm:"default:false"`
 	AllowExtraBody     bool    `json:"allow_extra_body" form:"allow_extra_body" gorm:"default:false"`
 
+	SystemPromptPrepend *string `json:"system_prompt_prepend" gorm:"type:text"`
+	SystemPromptAppend  *string `json:"system_prompt_append" gorm:"type:text"`
+
 	DisabledStream *datatypes.JSONSlice[string] `json:"disabled_stream,omitempty" gorm:"type:json"`
 
 	Plugin    *datatypes.JSONType[PluginType] `json:"plugin" form:"plugin" gorm:"type:json"`

--- a/relay/chat.go
+++ b/relay/chat.go
@@ -103,6 +103,7 @@ func (r *relayChat) send() (err *types.OpenAIErrorWithStatusCode, done bool) {
 	}
 
 	r.chatRequest.Model = r.modelName
+	r.applySystemPrompt()
 	// 内容审查
 	if config.EnableSafe {
 		for _, message := range r.chatRequest.Messages {
@@ -177,6 +178,47 @@ func (r *relayChat) getUsageResponse() string {
 	}
 
 	return ""
+}
+
+func (r *relayChat) applySystemPrompt() {
+	channel := r.provider.GetChannel()
+	prepend := ""
+	appendStr := ""
+	if channel.SystemPromptPrepend != nil {
+		prepend = *channel.SystemPromptPrepend
+	}
+	if channel.SystemPromptAppend != nil {
+		appendStr = *channel.SystemPromptAppend
+	}
+	if prepend == "" && appendStr == "" {
+		return
+	}
+
+	for i := range r.chatRequest.Messages {
+		if r.chatRequest.Messages[i].IsSystemRole() {
+			content := r.chatRequest.Messages[i].StringContent()
+			if prepend != "" {
+				content = prepend + "\n" + content
+			}
+			if appendStr != "" {
+				content = content + "\n" + appendStr
+			}
+			r.chatRequest.Messages[i].Content = content
+			return
+		}
+	}
+
+	content := prepend
+	if appendStr != "" {
+		if content != "" {
+			content += "\n"
+		}
+		content += appendStr
+	}
+	r.chatRequest.Messages = append([]types.ChatCompletionMessage{{
+		Role:    types.ChatMessageRoleSystem,
+		Content: content,
+	}}, r.chatRequest.Messages...)
 }
 
 func (r *relayChat) compatibleSend(resProvider providersBase.ResponsesInterface) (err *types.OpenAIErrorWithStatusCode, done bool) {

--- a/web/src/views/Channel/component/EditModal.jsx
+++ b/web/src/views/Channel/component/EditModal.jsx
@@ -376,6 +376,8 @@ const EditModal = ({ open, channelId, onCancel, onOk, groupOptions, isTag, model
         }
 
         data.base_url = data.base_url ?? '';
+        data.system_prompt_prepend = data.system_prompt_prepend ?? '';
+        data.system_prompt_append = data.system_prompt_append ?? '';
         data.is_edit = true;
         if (data.plugin === null) {
           data.plugin = {};
@@ -1091,6 +1093,40 @@ const EditModal = ({ open, channelId, onCancel, onOk, groupOptions, isTag, model
                     <FormHelperText id="helper-tex-allow_extra_body-label">{customizeT(inputPrompt.allow_extra_body)}</FormHelperText>
                   </FormControl>
                 )}
+                <FormControl fullWidth sx={{ ...theme.typography.otherInput }}>
+                  <TextField
+                    multiline
+                    id="channel-system_prompt_prepend-label"
+                    label={customizeT(inputLabel.system_prompt_prepend)}
+                    value={values.system_prompt_prepend}
+                    name="system_prompt_prepend"
+                    onBlur={handleBlur}
+                    onChange={handleChange}
+                    minRows={2}
+                    maxRows={8}
+                    placeholder={customizeT(inputPrompt.system_prompt_prepend)}
+                  />
+                  <FormHelperText id="helper-tex-channel-system_prompt_prepend-label">
+                    {customizeT(inputPrompt.system_prompt_prepend)}
+                  </FormHelperText>
+                </FormControl>
+                <FormControl fullWidth sx={{ ...theme.typography.otherInput }}>
+                  <TextField
+                    multiline
+                    id="channel-system_prompt_append-label"
+                    label={customizeT(inputLabel.system_prompt_append)}
+                    value={values.system_prompt_append}
+                    name="system_prompt_append"
+                    onBlur={handleBlur}
+                    onChange={handleChange}
+                    minRows={2}
+                    maxRows={8}
+                    placeholder={customizeT(inputPrompt.system_prompt_append)}
+                  />
+                  <FormHelperText id="helper-tex-channel-system_prompt_append-label">
+                    {customizeT(inputPrompt.system_prompt_append)}
+                  </FormHelperText>
+                </FormControl>
                 {pluginList[values.type] &&
                   Object.keys(pluginList[values.type]).map((pluginId) => {
                     const plugin = pluginList[values.type][pluginId];

--- a/web/src/views/Channel/type/Config.js
+++ b/web/src/views/Channel/type/Config.js
@@ -18,7 +18,9 @@ const defaultConfig = {
     pre_cost: 1,
     disabled_stream: [],
     compatible_response: false,
-    allow_extra_body: false
+    allow_extra_body: false,
+    system_prompt_prepend: '',
+    system_prompt_append: ''
   },
   inputLabel: {
     name: '渠道名称',
@@ -39,7 +41,9 @@ const defaultConfig = {
     pre_cost: '预计费选项',
     disabled_stream: '禁用流式的模型',
     compatible_response: '兼容Response API',
-    allow_extra_body: '允许额外字段透传'
+    allow_extra_body: '允许额外字段透传',
+    system_prompt_prepend: '系统提示词前缀',
+    system_prompt_append: '系统提示词后缀'
   },
   prompt: {
     type: '请选择渠道类型',
@@ -64,7 +68,9 @@ const defaultConfig = {
       '这里选择预计费选项，用于预估费用，如果你觉得计算图片占用太多资源，可以选择关闭图片计费。但是请注意：有些渠道在stream下是不会返回tokens的，这会导致输入tokens计算错误。',
     disabled_stream: '这里填写禁用流式的模型，注意：如果填写了禁用流式的模型，那么这些模型在流式请求时会跳过该渠道',
     compatible_response: '兼容Response API',
-    allow_extra_body: '开启后，将会透传用户请求中的额外字段（如OpenAI SDK的extra_body参数），适用于需要传递自定义参数到上游API的场景'
+    allow_extra_body: '开启后，将会透传用户请求中的额外字段（如OpenAI SDK的extra_body参数），适用于需要传递自定义参数到上游API的场景',
+    system_prompt_prepend: '在系统提示词之前添加的内容，留空则不添加',
+    system_prompt_append: '在系统提示词之后添加的内容，留空则不添加'
   },
   modelGroup: 'OpenAI'
 };


### PR DESCRIPTION
close #849

Added the ability to prepend and append text to system prompts on a per-channel basis. Lets users inject custom instructions at the start or end of the system message without having to manually edit the full prompt.

Implementation adds two optional fields to the Channel model, then applies them during chat relay by finding the existing system message and concatenating the text. If no system message exists, it creates one. Also updated the channel editor UI to expose these fields.

Tested locally with prepend only, append only, and both combined. All working correctly, screenshots attached.