### PR TITLE
Simplify retry logic for timeout errors

### DIFF
--- a/relay/common.go
+++ b/relay/common.go
@@ -513,7 +513,7 @@ func shouldRetry(c *gin.Context, apiErr *types.OpenAIErrorWithStatusCode, channe
 	switch apiErr.StatusCode {
 	case http.StatusTooManyRequests, http.StatusTemporaryRedirect:
 		return true
-	case http.StatusRequestTimeout, http.StatusGatewayTimeout, 524:
+	case http.StatusRequestTimeout:
 		return false
 	case http.StatusBadRequest:
 		return shouldRetryBadRequest(channelType, apiErr)

--- a/relay/task/suno/submit.go
+++ b/relay/task/suno/submit.go
@@ -144,10 +144,6 @@ func (t *SunoTask) ShouldRetry(c *gin.Context, err *base.TaskError) bool {
 	}
 
 	if err.StatusCode/100 == 5 {
-		// 超时不重试
-		if err.StatusCode == 504 || err.StatusCode == 524 {
-			return false
-		}
 		return true
 	}
 


### PR DESCRIPTION
close #852

The retry logic was being too restrictive with timeout errors. Removed the special cases that were preventing retries for 504 and 524 status codes, since these are generally retriable errors (server-side issues).

Made two changes:
- In `relay/common.go`: Stop treating gateway timeouts (504) and 524 as non-retriable
- In `relay/task/suno/submit.go`: Removed the duplicate timeout check that was preventing retries on 5xx errors

This makes the retry behavior more consistent and lets the system retry on temporary server issues like it should.

我已确认该 PR 已自测通过，相关截图如下：

N/A