### PR TITLE
Add parameter deletion via __delete__ sentinel value

### DIFF
--- a/providers/openai/base.go
+++ b/providers/openai/base.go
@@ -231,6 +231,10 @@ func (p *OpenAIProvider) mergeCustomParams(requestMap map[string]interface{}, cu
 		if key == "stream" || key == "overwrite" || key == "per_model" || key == "pre_add" {
 			continue
 		}
+		if strVal, ok := value.(string); ok && strVal == "__delete__" {
+			delete(requestMap, key)
+			continue
+		}
 		// 根据覆盖设置决定如何添加参数
 		if shouldOverwrite {
 			// 覆盖模式：直接添加/覆盖参数

--- a/relay/common.go
+++ b/relay/common.go
@@ -650,6 +650,11 @@ func mergeCustomParamsForPreMapping(requestMap map[string]interface{}, customPar
 			continue
 		}
 
+		if strVal, ok := value.(string); ok && strVal == "__delete__" {
+			delete(requestMap, key)
+			continue
+		}
+
 		// 根据覆盖设置决定如何添加参数
 		if shouldOverwrite {
 			// 覆盖模式：直接添加/覆盖参数

--- a/relay/common_test.go
+++ b/relay/common_test.go
@@ -1,0 +1,60 @@
+package relay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeCustomParamsForPreMapping_Delete(t *testing.T) {
+	requestMap := map[string]interface{}{
+		"model":       "gpt-4",
+		"temperature": 0.7,
+		"top_p":       1.0,
+	}
+	customParams := map[string]interface{}{
+		"overwrite":   true,
+		"temperature": "__delete__",
+	}
+
+	result := mergeCustomParamsForPreMapping(requestMap, customParams)
+
+	_, exists := result["temperature"]
+	assert.False(t, exists, "temperature should be deleted")
+	assert.Equal(t, 1.0, result["top_p"])
+}
+
+func TestMergeCustomParamsForPreMapping_DeleteNonExistent(t *testing.T) {
+	requestMap := map[string]interface{}{
+		"model": "gpt-4",
+	}
+	customParams := map[string]interface{}{
+		"overwrite":   true,
+		"temperature": "__delete__",
+	}
+
+	result := mergeCustomParamsForPreMapping(requestMap, customParams)
+
+	_, exists := result["temperature"]
+	assert.False(t, exists, "deleting a non-existent key should be a no-op")
+}
+
+func TestMergeCustomParamsForPreMapping_DeleteDoesNotAffectOtherKeys(t *testing.T) {
+	requestMap := map[string]interface{}{
+		"model":       "gpt-4",
+		"temperature": 0.7,
+		"top_p":       1.0,
+	}
+	customParams := map[string]interface{}{
+		"overwrite":   true,
+		"temperature": "__delete__",
+		"max_tokens":  100,
+	}
+
+	result := mergeCustomParamsForPreMapping(requestMap, customParams)
+
+	_, exists := result["temperature"]
+	assert.False(t, exists)
+	assert.Equal(t, 100, result["max_tokens"])
+	assert.Equal(t, 1.0, result["top_p"])
+}


### PR DESCRIPTION
Closes #908

Added support for deleting parameters by passing `"__delete__"` as the custom parameter value. This lets users remove specific keys from the request without having to pass null or empty values.

Implemented the check in both the OpenAI provider merge function and the common pre-mapping merge function to cover all parameter merge paths. The logic is straightforward - if a custom param value is the string `"__delete__"`, we just delete that key from the request map instead of setting it.

Added three test cases covering the main scenarios: deleting an existing key, attempting to delete a non-existent key (no-op), and making sure deletion doesn't affect other parameters being set in the same call.

Tested locally with the provided test cases, all passing.